### PR TITLE
made extrenal schema references local + other improvements to structures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 .DS_Store
+.vscode

--- a/README.md
+++ b/README.md
@@ -27,6 +27,10 @@ In order to have your contributions accepted you MUST:
 3. Run all tests locally and ensure they are all passing.
 4. Generate the latest version of the spec to include your changes to vocabular / data model.
 5. Open a Pull Request with your changes, a clear description of them in the description, and passing CI Tests.
+6. Any references to schemas you wish to include in your schema should be recreated locally and referenced there.  In these local schemas, only include the properties relevant to the schema you have created.  For example, [Person](https://schema.org/Person) is an existing schema on schema.org, but a Person.json schema has been added to this repo, including only the relevant and used properties for the other traceability schemas.  This is to hopefully make traceability schemas easier to understand and manage by not incorporating too many unnecessarily large schemas.  The schemas that have been made local in this way (like Person.json) should still reference the schema.org entry like so:
+```
+    "$comment": "{\"term\": \"Person\", \"@id\": \"https://schema.org/Person\"}",
+```
 
 #### Contributing to Vocabulary
 
@@ -71,6 +75,9 @@ and adding the path:
 5. review the latest spec changes by serving docs: `npx serve ./docs`.
 
 Follow the conventions established for the other properties, for example:
+
+###### Helpful Tips
+- Ensure 
 
 ###### Place
 

--- a/docs/contexts/traceability-v1.jsonld
+++ b/docs/contexts/traceability-v1.jsonld
@@ -14,16 +14,16 @@
       "@id": "https://w3id.org/traceability/AgInspectionReport",
       "@context": {
         "facility": {
-          "@id": "https://schema.org/Place"
+          "@id": "https://w3id.org/traceability/schemas/Place.json"
         },
         "inspector": {
-          "@id": "https://w3id.org/traceability/schemas/inspector"
+          "@id": "https://w3id.org/traceability/schemas/Inspector"
         },
         "shipment": {
           "@id": "https://schema.org/ParcelDelivery"
         },
-        "applicantId": {
-          "@id": "https://schema.org/identifier"
+        "applicant": {
+          "@id": "https://w3id.org/traceability/schemas/Entity"
         },
         "inspectionDate": {
           "@id": "https://schema.org/DateTime"
@@ -70,6 +70,10 @@
         }
       }
     },
+    "Entity": {
+      "@id": "https://w3id.org/traceability/Entity",
+      "@context": {}
+    },
     "GeoCoordinates": {
       "@id": "https://schema.org/GeoCoordinates",
       "@context": {
@@ -93,7 +97,7 @@
       "@id": "https://w3id.org/traceability/Inspector",
       "@context": {
         "person": {
-          "@id": "https://schema.org/Person"
+          "@id": "https://w3id.org/traceability/schemas/Person.json"
         },
         "credential": {
           "@id": "https://schema.org/ItemList"
@@ -140,6 +144,66 @@
         }
       }
     },
+    "Organization": {
+      "@id": "https://schema.org/Organization",
+      "@context": {
+        "name": {
+          "@id": "https://schema.org/name"
+        },
+        "description": {
+          "@id": "https://schema.org/description"
+        },
+        "address": {
+          "@id": "https://schema.org/PostalAddress"
+        },
+        "email": {
+          "@id": "https://schema.org/email"
+        },
+        "phoneNumber": {
+          "@id": "https://schema.org/telephone"
+        }
+      }
+    },
+    "ParcelDelivery": {
+      "@id": "https://schema.org/ParcelDelivery",
+      "@context": {
+        "deliveryAddress": {
+          "@id": "https://schema.org/deliveryAddress"
+        },
+        "originAddress": {
+          "@id": "https://schema.org/originAddress"
+        },
+        "trackingNumber": {
+          "@id": "https://schema.org/trackingNumber"
+        },
+        "products": {
+          "@id": "https://schema.org/ItemList"
+        }
+      }
+    },
+    "Person": {
+      "@id": "https://schema.org/Person",
+      "@context": {
+        "firstName": {
+          "@id": "https://schema.org/givenName"
+        },
+        "lastName": {
+          "@id": "https://schema.org/familyName"
+        },
+        "email": {
+          "@id": "https://schema.org/email"
+        },
+        "phoneNumber": {
+          "@id": "https://schema.org/telephone"
+        },
+        "worksFor": {
+          "@id": "https://schema.org/worksFor"
+        },
+        "jobTitle": {
+          "@id": "https://schema.org/jobTitle"
+        }
+      }
+    },
     "Place": {
       "@id": "https://schema.org/Place",
       "@context": {
@@ -183,6 +247,40 @@
         },
         "postOfficeBoxNumber": {
           "@id": "https://schema.org/postOfficeBoxNumber"
+        }
+      }
+    },
+    "Product": {
+      "@id": "https://schema.org/Product",
+      "@context": {
+        "manufacturer": {
+          "@id": "https://schema.org/manufacturer"
+        },
+        "name": {
+          "@id": "https://schema.org/name"
+        },
+        "description": {
+          "@id": "https://schema.org/description"
+        },
+        "sizeOrAmount": {
+          "@id": "https://schema.org/size"
+        },
+        "weight": {
+          "@id": "https://schema.org/weight"
+        },
+        "sku": {
+          "@id": "https://schema.org/sku"
+        }
+      }
+    },
+    "QuantitativeValue": {
+      "@id": "https://schema.org/QuantitativeValue",
+      "@context": {
+        "unitCode": {
+          "@id": "https://schema.org/unitCode"
+        },
+        "value": {
+          "@id": "https://schema.org/value"
         }
       }
     }

--- a/docs/index.html
+++ b/docs/index.html
@@ -333,18 +333,18 @@
     "title": "Agriculture Inspection Report",
     "description": "Information on the Inspection and the observations made",
     "classProperties": {
-      "https://schema.org/Place": {
+      "https://w3id.org/traceability/schemas/Place.json": {
         "$comment": {
           "term": "facility",
-          "@id": "https://schema.org/Place"
+          "@id": "https://w3id.org/traceability/schemas/Place.json"
         },
         "title": "Facility Identifier",
         "description": "Identifiers for an inspection facility."
       },
-      "https://w3id.org/traceability/schemas/inspector": {
+      "https://w3id.org/traceability/schemas/Inspector": {
         "$comment": {
           "term": "inspector",
-          "@id": "https://w3id.org/traceability/schemas/inspector"
+          "@id": "https://w3id.org/traceability/schemas/Inspector"
         },
         "title": "Inspector",
         "description": "Inspector performing the Aggriculture Inspection"
@@ -357,13 +357,13 @@
         "title": "Shipment",
         "description": "Details for a shipment of goods."
       },
-      "https://schema.org/identifier": {
+      "https://w3id.org/traceability/schemas/Entity": {
         "$comment": {
-          "term": "applicantId",
-          "@id": "https://schema.org/identifier"
+          "term": "applicant",
+          "@id": "https://w3id.org/traceability/schemas/Entity"
         },
-        "title": "Applicant Identifier",
-        "description": "Identifiers for the entity inspection applicant."
+        "title": "Applicant",
+        "description": "Entity that is applying for the inspection."
       },
       "https://schema.org/DateTime": {
         "$comment": {
@@ -391,7 +391,602 @@
         "description": "List of observations"
       }
     },
-    "examples": [],
+    "examples": [
+      {
+        "@context": [
+          "https://w3id.org/traceability/v1"
+        ],
+        "type": "AgInspectionReport",
+        "facility": {
+          "type": "Place",
+          "globalLocationNumber": "5094112557724",
+          "geo": {
+            "type": "GeoCoordinates",
+            "latitude": "6.9367",
+            "longitude": "70.2528"
+          },
+          "address": {
+            "type": "PostalAddress",
+            "organizationName": "Swift - Larkin",
+            "streetAddress": "1167 Nelle Wells",
+            "addressLocality": "Caroleville",
+            "addressRegion": "North Carolina",
+            "postalCode": "17085-4582",
+            "addressCountry": "Puerto Rico"
+          }
+        },
+        "inspector": {
+          "type": "Inspector",
+          "person": {
+            "type": "Person",
+            "firstName": "Sofia",
+            "lastName": "Runolfsdottir",
+            "email": "Edgardo17@hotmail.com",
+            "phoneNumber": "(874) 571-1664 x187",
+            "worksFor": {
+              "type": "Organization",
+              "name": "Conroy, Herman and Kreiger",
+              "description": "Quality-focused bifurcated moratorium",
+              "address": {
+                "type": "PostalAddress",
+                "streetAddress": "066 Rahul Squares",
+                "addressLocality": "D'Amorefurt",
+                "addressRegion": "Delaware",
+                "postalCode": "16365-8130",
+                "addressCountry": "Croatia"
+              },
+              "email": "Elinor64@gmail.com",
+              "phoneNumber": "(501) 413-3480 x274"
+            },
+            "jobTitle": "Direct Mobility Officer"
+          },
+          "credential": [
+            {
+              "type": "Credential",
+              "credentialCategory": "District Infrastructure Specialist",
+              "credentialValue": "Agent"
+            },
+            {
+              "type": "Credential",
+              "credentialCategory": "National Implementation Coordinator",
+              "credentialValue": "Technician"
+            }
+          ]
+        },
+        "shipment": {
+          "type": "ParcelDelivery",
+          "deliveryAddress": {
+            "type": "PostalAddress",
+            "organizationName": "Ortiz, Pouros and Steuber",
+            "streetAddress": "0553 Xander Parkway",
+            "addressLocality": "South Skye",
+            "addressRegion": "Connecticut",
+            "postalCode": "86326",
+            "addressCountry": "Iraq"
+          },
+          "originAddress": {
+            "type": "PostalAddress",
+            "organizationName": "Boyle, Hane and Corkery",
+            "streetAddress": "987 Cameron Valley",
+            "addressLocality": "New Electaburgh",
+            "addressRegion": "Nevada",
+            "postalCode": "48332-0620",
+            "addressCountry": "Gibraltar"
+          },
+          "trackingNumber": "503164088156",
+          "products": [
+            {
+              "type": "Product",
+              "manufacturer": {
+                "type": "Organization",
+                "name": "Heaney - Grady",
+                "description": "Reverse-engineered client-driven matrix",
+                "address": {
+                  "type": "PostalAddress",
+                  "streetAddress": "1870 Hintz Terrace",
+                  "addressLocality": "South Abbey",
+                  "addressRegion": "Iowa",
+                  "postalCode": "42210",
+                  "addressCountry": "Republic of Korea"
+                },
+                "email": "Brock.Hartmann82@yahoo.com",
+                "phoneNumber": "461-525-5187 x42208"
+              },
+              "name": "Small Plastic Bacon",
+              "description": "Carbonite web goalkeeper gloves are ergonomically designed to give easy fit",
+              "sizeOrAmount": {
+                "type": "QuantitativeValue",
+                "unitCode": "hg/ha",
+                "value": "6178"
+              },
+              "weight": {
+                "type": "QuantitativeValue",
+                "unitCode": "hg/ha",
+                "value": "5960"
+              },
+              "sku": "88259203676"
+            }
+          ]
+        },
+        "applicant": {
+          "type": "Person",
+          "firstName": "Jaylon",
+          "lastName": "Bradtke",
+          "email": "Zane_Pollich39@yahoo.com",
+          "phoneNumber": "847-262-8755",
+          "worksFor": {
+            "type": "Organization",
+            "name": "Gaylord, Brown and Kunde",
+            "description": "Persevering interactive protocol",
+            "address": {
+              "type": "PostalAddress",
+              "streetAddress": "657 Beverly Hills",
+              "addressLocality": "Rogahnfurt",
+              "addressRegion": "New Mexico",
+              "postalCode": "73208",
+              "addressCountry": "Iran"
+            },
+            "email": "Jana_Hagenes@gmail.com",
+            "phoneNumber": "1-731-783-9434 x174"
+          },
+          "jobTitle": "Central Paradigm Facilitator"
+        },
+        "inspectionDate": "11-2-2020",
+        "inspectionType": "Phytosanitary",
+        "observation": [
+          {
+            "type": "Observation",
+            "property": {
+              "type": "ChemicalProperty",
+              "name": "Ruthenium",
+              "formula": "Ru",
+              "inchi": "InChI=1S/Ru",
+              "inchikey": "KJTLSVCANCCWHF-UHFFFAOYSA-N"
+            },
+            "measurement": {
+              "value": "88.180",
+              "unitCode": "P1"
+            }
+          },
+          {
+            "type": "Observation",
+            "property": {
+              "type": "ChemicalProperty",
+              "name": "Lawrencium",
+              "formula": "Lr",
+              "inchi": "InChI=1S/Lr",
+              "inchikey": "CNQCVBJFEGMYDW-UHFFFAOYSA-N"
+            },
+            "measurement": {
+              "value": "11.820",
+              "unitCode": "P1"
+            }
+          }
+        ]
+      },
+      {
+        "@context": [
+          "https://w3id.org/traceability/v1"
+        ],
+        "type": "AgInspectionReport",
+        "facility": {
+          "type": "Place",
+          "globalLocationNumber": "5461635410698",
+          "geo": {
+            "type": "GeoCoordinates",
+            "latitude": "9.6831",
+            "longitude": "38.8686"
+          },
+          "address": {
+            "type": "PostalAddress",
+            "organizationName": "Veum - Tillman",
+            "streetAddress": "43086 Margaret Parks",
+            "addressLocality": "Ritchiemouth",
+            "addressRegion": "South Carolina",
+            "postalCode": "34553-8056",
+            "addressCountry": "Taiwan"
+          }
+        },
+        "inspector": {
+          "type": "Inspector",
+          "person": {
+            "type": "Person",
+            "firstName": "Lucio",
+            "lastName": "Bosco",
+            "email": "Nedra_Beahan@gmail.com",
+            "phoneNumber": "493.926.1850 x981",
+            "worksFor": {
+              "type": "Organization",
+              "name": "Herman, Langworth and Shanahan",
+              "description": "Integrated dedicated methodology",
+              "address": {
+                "type": "PostalAddress",
+                "streetAddress": "41419 Metz Camp",
+                "addressLocality": "Lake Althea",
+                "addressRegion": "Virginia",
+                "postalCode": "93531",
+                "addressCountry": "Gambia"
+              },
+              "email": "Melvin_Wisozk@hotmail.com",
+              "phoneNumber": "1-907-898-1822 x31897"
+            },
+            "jobTitle": "Dynamic Infrastructure Technician"
+          },
+          "credential": [
+            {
+              "type": "Credential",
+              "credentialCategory": "Forward Mobility Agent",
+              "credentialValue": "Orchestrator"
+            }
+          ]
+        },
+        "shipment": {
+          "type": "ParcelDelivery",
+          "deliveryAddress": {
+            "type": "PostalAddress",
+            "organizationName": "Williamson - Tromp",
+            "streetAddress": "399 Demetris Dam",
+            "addressLocality": "West Malloryborough",
+            "addressRegion": "Wisconsin",
+            "postalCode": "17952-8678",
+            "addressCountry": "Guatemala"
+          },
+          "originAddress": {
+            "type": "PostalAddress",
+            "organizationName": "Johns, Krajcik and Windler",
+            "streetAddress": "938 Bednar Locks",
+            "addressLocality": "East Noelshire",
+            "addressRegion": "Ohio",
+            "postalCode": "15758",
+            "addressCountry": "Denmark"
+          },
+          "trackingNumber": "551197846908",
+          "products": [
+            {
+              "type": "Product",
+              "manufacturer": {
+                "type": "Person",
+                "firstName": "Russell",
+                "lastName": "Lehner",
+                "email": "Dell20@yahoo.com",
+                "phoneNumber": "820.558.7250",
+                "worksFor": {
+                  "type": "Organization",
+                  "name": "Durgan - Brown",
+                  "description": "Devolved global monitoring",
+                  "address": {
+                    "type": "PostalAddress",
+                    "streetAddress": "8055 Gerlach Roads",
+                    "addressLocality": "Port Sibyl",
+                    "addressRegion": "Louisiana",
+                    "postalCode": "61304-3589",
+                    "addressCountry": "Azerbaijan"
+                  },
+                  "email": "Diana_Bartoletti@yahoo.com",
+                  "phoneNumber": "1-924-561-8943"
+                },
+                "jobTitle": "Dynamic Security Facilitator"
+              },
+              "name": "Tasty Steel Gloves",
+              "description": "Carbonite web goalkeeper gloves are ergonomically designed to give easy fit",
+              "sizeOrAmount": {
+                "type": "QuantitativeValue",
+                "unitCode": "hg/ha",
+                "value": "2393"
+              },
+              "weight": {
+                "type": "QuantitativeValue",
+                "unitCode": "hg/ha",
+                "value": "5415"
+              },
+              "sku": "950856140054"
+            }
+          ]
+        },
+        "applicant": {
+          "type": "Person",
+          "firstName": "Alverta",
+          "lastName": "Jacobs",
+          "email": "Brayan_Veum@yahoo.com",
+          "phoneNumber": "1-753-463-1245 x04543",
+          "worksFor": {
+            "type": "Organization",
+            "name": "Hyatt Group",
+            "description": "Customer-focused value-added interface",
+            "address": {
+              "type": "PostalAddress",
+              "streetAddress": "21199 Keely Squares",
+              "addressLocality": "Binsberg",
+              "addressRegion": "Indiana",
+              "postalCode": "85119-2230",
+              "addressCountry": "Saint Barthelemy"
+            },
+            "email": "Chadrick.Carter@yahoo.com",
+            "phoneNumber": "1-947-251-7218"
+          },
+          "jobTitle": "National Tactics Technician"
+        },
+        "inspectionDate": "11-2-2020",
+        "inspectionType": "Phytosanitary",
+        "observation": [
+          {
+            "type": "Observation",
+            "property": {
+              "type": "ChemicalProperty",
+              "name": "Iodine",
+              "formula": "I",
+              "inchi": "InChI=1S/I",
+              "inchikey": "ZCYVEMRRCGMTRW-UHFFFAOYSA-N"
+            },
+            "measurement": {
+              "value": "35.694",
+              "unitCode": "P1"
+            }
+          },
+          {
+            "type": "Observation",
+            "property": {
+              "type": "ChemicalProperty",
+              "name": "Strontium",
+              "formula": "Sr",
+              "inchi": "InChI=1S/Sr",
+              "inchikey": "CIOAGBVUUVVLOB-UHFFFAOYSA-N"
+            },
+            "measurement": {
+              "value": "42.049",
+              "unitCode": "P1"
+            }
+          },
+          {
+            "type": "Observation",
+            "property": {
+              "type": "ChemicalProperty",
+              "name": "Helium",
+              "formula": "He",
+              "inchi": "InChI=1S/He",
+              "inchikey": "SWQJXJOGLNCZEY-UHFFFAOYSA-N"
+            },
+            "measurement": {
+              "value": "1.1345",
+              "unitCode": "P1"
+            }
+          },
+          {
+            "type": "Observation",
+            "property": {
+              "type": "ChemicalProperty",
+              "name": "Platinum",
+              "formula": "Pt",
+              "inchi": "InChI=1S/Pt",
+              "inchikey": "BASFCYQUMIYNBI-UHFFFAOYSA-N"
+            },
+            "measurement": {
+              "value": "21.122",
+              "unitCode": "P1"
+            }
+          }
+        ]
+      },
+      {
+        "@context": [
+          "https://w3id.org/traceability/v1"
+        ],
+        "type": "AgInspectionReport",
+        "facility": {
+          "type": "Place",
+          "globalLocationNumber": "4013194867881",
+          "geo": {
+            "type": "GeoCoordinates",
+            "latitude": "-25.5339",
+            "longitude": "-153.9454"
+          },
+          "address": {
+            "type": "PostalAddress",
+            "organizationName": "Bashirian - Bode",
+            "streetAddress": "6204 Abe Port",
+            "addressLocality": "Gorczanyside",
+            "addressRegion": "California",
+            "postalCode": "24005",
+            "addressCountry": "Kenya"
+          }
+        },
+        "inspector": {
+          "type": "Inspector",
+          "person": {
+            "type": "Person",
+            "firstName": "Michele",
+            "lastName": "Rosenbaum",
+            "email": "Addie76@hotmail.com",
+            "phoneNumber": "334-491-6248 x09191",
+            "worksFor": {
+              "type": "Organization",
+              "name": "Smith, Stroman and Kuhlman",
+              "description": "Profit-focused interactive neural-net",
+              "address": {
+                "type": "PostalAddress",
+                "streetAddress": "779 Gottlieb Port",
+                "addressLocality": "New Hilariotown",
+                "addressRegion": "Florida",
+                "postalCode": "13297-1232",
+                "addressCountry": "Hong Kong"
+              },
+              "email": "Katelyn_Gleichner@yahoo.com",
+              "phoneNumber": "(826) 938-4901"
+            },
+            "jobTitle": "Human Factors Officer"
+          },
+          "credential": [
+            {
+              "type": "Credential",
+              "credentialCategory": "Central Integration Director",
+              "credentialValue": "Officer"
+            },
+            {
+              "type": "Credential",
+              "credentialCategory": "Dynamic Data Architect",
+              "credentialValue": "Representative"
+            }
+          ]
+        },
+        "shipment": {
+          "type": "ParcelDelivery",
+          "deliveryAddress": {
+            "type": "PostalAddress",
+            "organizationName": "Bogisich - Gibson",
+            "streetAddress": "6276 Huels Parkways",
+            "addressLocality": "East Harmony",
+            "addressRegion": "South Dakota",
+            "postalCode": "12101",
+            "addressCountry": "Antarctica (the territory South of 60 deg S)"
+          },
+          "originAddress": {
+            "type": "PostalAddress",
+            "organizationName": "Mayer and Sons",
+            "streetAddress": "027 Hermiston Groves",
+            "addressLocality": "Nikolausborough",
+            "addressRegion": "Rhode Island",
+            "postalCode": "55608",
+            "addressCountry": "Ecuador"
+          },
+          "trackingNumber": "377822965748",
+          "products": [
+            {
+              "type": "Product",
+              "manufacturer": {
+                "type": "Organization",
+                "name": "Carroll and Sons",
+                "description": "Reduced stable hub",
+                "address": {
+                  "type": "PostalAddress",
+                  "streetAddress": "5515 Dibbert Fall",
+                  "addressLocality": "West Myrtie",
+                  "addressRegion": "Alaska",
+                  "postalCode": "74404-9344",
+                  "addressCountry": "Netherlands"
+                },
+                "email": "Willow.Labadie46@gmail.com",
+                "phoneNumber": "1-378-469-2484 x931"
+              },
+              "name": "Gorgeous Concrete Shirt",
+              "description": "Ergonomic executive chair upholstered in bonded black leather and PVC padded seat and back for all-day comfort and support",
+              "sizeOrAmount": {
+                "type": "QuantitativeValue",
+                "unitCode": "hg/ha",
+                "value": "9030"
+              },
+              "weight": {
+                "type": "QuantitativeValue",
+                "unitCode": "hg/ha",
+                "value": "5692"
+              },
+              "sku": "738393217334"
+            },
+            {
+              "type": "Product",
+              "manufacturer": {
+                "type": "Organization",
+                "name": "Turner, Kihn and Crona",
+                "description": "Public-key full-range open architecture",
+                "address": {
+                  "type": "PostalAddress",
+                  "streetAddress": "412 Elsa Plain",
+                  "addressLocality": "Schillerside",
+                  "addressRegion": "Kansas",
+                  "postalCode": "07159",
+                  "addressCountry": "Nigeria"
+                },
+                "email": "Anabelle.Rohan43@hotmail.com",
+                "phoneNumber": "1-456-889-9848"
+              },
+              "name": "Gorgeous Rubber Table",
+              "description": "The beautiful range of Apple Naturalé that has an exciting mix of natural ingredients. With the Goodness of 100% Natural Ingredients",
+              "sizeOrAmount": {
+                "type": "QuantitativeValue",
+                "unitCode": "hg/ha",
+                "value": "8920"
+              },
+              "weight": {
+                "type": "QuantitativeValue",
+                "unitCode": "hg/ha",
+                "value": "6527"
+              },
+              "sku": "819915551842"
+            },
+            {
+              "type": "Product",
+              "manufacturer": {
+                "type": "Person",
+                "firstName": "Demarco",
+                "lastName": "Turcotte",
+                "email": "Pietro_McCullough@gmail.com",
+                "phoneNumber": "1-492-931-1296",
+                "worksFor": {
+                  "type": "Organization",
+                  "name": "Mertz, Labadie and Lindgren",
+                  "description": "Face to face composite structure",
+                  "address": {
+                    "type": "PostalAddress",
+                    "streetAddress": "052 Chaz Fort",
+                    "addressLocality": "Hellerton",
+                    "addressRegion": "Pennsylvania",
+                    "postalCode": "44591",
+                    "addressCountry": "Sierra Leone"
+                  },
+                  "email": "Asia99@gmail.com",
+                  "phoneNumber": "401-762-5146"
+                },
+                "jobTitle": "Customer Functionality Orchestrator"
+              },
+              "name": "Handmade Rubber Pizza",
+              "description": "Andy shoes are designed to keeping in mind durability as well as trends, the most stylish range of shoes & sandals",
+              "sizeOrAmount": {
+                "type": "QuantitativeValue",
+                "unitCode": "hg/ha",
+                "value": "2979"
+              },
+              "weight": {
+                "type": "QuantitativeValue",
+                "unitCode": "hg/ha",
+                "value": "8985"
+              },
+              "sku": "234438850760"
+            }
+          ]
+        },
+        "applicant": {
+          "type": "Organization",
+          "name": "Botsford and Sons",
+          "description": "Configurable empowering flexibility",
+          "address": {
+            "type": "PostalAddress",
+            "streetAddress": "222 Cruickshank Ville",
+            "addressLocality": "West Marielle",
+            "addressRegion": "Michigan",
+            "postalCode": "45148",
+            "addressCountry": "Guadeloupe"
+          },
+          "email": "Shanon.Marvin51@hotmail.com",
+          "phoneNumber": "1-282-246-1499 x7539"
+        },
+        "inspectionDate": "11-1-2020",
+        "inspectionType": "General",
+        "observation": [
+          {
+            "type": "Observation",
+            "property": {
+              "type": "MechanicalProperty",
+              "identifier": "ISO 180",
+              "name": "Izod Impact Strength Test",
+              "description": "ISO 180 defines the method used for pendulums to determine the impact resistance of a plastic specimen when supported in a cantilever configuration. Test results are used to evaluate the resilience of materials, typically plastics."
+            },
+            "measurement": {
+              "value": "81.647",
+              "unitCode": "B13"
+            }
+          }
+        ]
+      }
+    ],
     "schema": {
       "$id": "https://w3id.org/traceability/schemas/AgInspectionReport.json",
       "$schema": "http://json-schema.org/draft-07/schema#",
@@ -414,13 +1009,13 @@
           ]
         },
         "facility": {
-          "$comment": "{\"term\": \"facility\", \"@id\": \"https://schema.org/Place\"}",
+          "$comment": "{\"term\": \"facility\", \"@id\": \"https://w3id.org/traceability/schemas/Place.json\"}",
           "title": "Facility Identifier",
           "description": "Identifiers for an inspection facility.",
           "$ref": "https://w3id.org/traceability/schemas/Place.json"
         },
         "inspector": {
-          "$comment": "{\"term\": \"inspector\", \"@id\": \"https://w3id.org/traceability/schemas/inspector\"}",
+          "$comment": "{\"term\": \"inspector\", \"@id\": \"https://w3id.org/traceability/schemas/Inspector\"}",
           "title": "Inspector",
           "description": "Inspector performing the Aggriculture Inspection",
           "$ref": "https://w3id.org/traceability/schemas/Inspector.json"
@@ -429,13 +1024,13 @@
           "$comment": "{\"term\": \"shipment\", \"@id\": \"https://schema.org/ParcelDelivery\"}",
           "title": "Shipment",
           "description": "Details for a shipment of goods.",
-          "$ref": "https://schema.org/version/latest/schemaorg-current-http.jsonld#https://schema.org/ParcelDelivery"
+          "$ref": "https://w3id.org/traceability/schemas/ParcelDelivery.json"
         },
-        "applicantId": {
-          "$comment": "{\"term\": \"applicantId\", \"@id\": \"https://schema.org/identifier\"}",
-          "title": "Applicant Identifier",
-          "description": "Identifiers for the entity inspection applicant.",
-          "type": "string"
+        "applicant": {
+          "$comment": "{\"term\": \"applicant\", \"@id\": \"https://w3id.org/traceability/schemas/Entity\"}",
+          "title": "Applicant",
+          "description": "Entity that is applying for the inspection.",
+          "$ref": "https://w3id.org/traceability/schemas/Entity.json"
         },
         "inspectionDate": {
           "$comment": "{\"term\": \"inspectionDate\", \"@id\": \"https://schema.org/DateTime\"}",
@@ -649,24 +1244,24 @@
           "https://w3id.org/traceability/v1"
         ],
         "type": "Credential",
-        "credentialCategory": "Forward Quality Officer",
-        "credentialValue": "Engineer"
+        "credentialCategory": "Senior Creative Facilitator",
+        "credentialValue": "Manager"
       },
       {
         "@context": [
           "https://w3id.org/traceability/v1"
         ],
         "type": "Credential",
-        "credentialCategory": "International Response Specialist",
-        "credentialValue": "Architect"
+        "credentialCategory": "Senior Functionality Manager",
+        "credentialValue": "Strategist"
       },
       {
         "@context": [
           "https://w3id.org/traceability/v1"
         ],
         "type": "Credential",
-        "credentialCategory": "Principal Infrastructure Technician",
-        "credentialValue": "Specialist"
+        "credentialCategory": "Customer Optimization Producer",
+        "credentialValue": "Administrator"
       }
     ],
     "schema": {
@@ -704,6 +1299,89 @@
         }
       },
       "additionalProperties": false,
+      "examples": []
+    }
+  },
+  "https://w3id.org/traceability/Entity": {
+    "$id": "https://w3id.org/traceability/schemas/Entity.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$comment": {
+      "term": "Entity",
+      "@id": "https://w3id.org/traceability/Entity"
+    },
+    "title": "Entity",
+    "description": "A person or organization.",
+    "classProperties": {},
+    "examples": [
+      {
+        "@context": [
+          "https://w3id.org/traceability/v1"
+        ],
+        "type": "Organization",
+        "name": "Buckridge Group",
+        "description": "Enhanced human-resource benchmark",
+        "address": {
+          "type": "PostalAddress",
+          "streetAddress": "2711 Nikki Keys",
+          "addressLocality": "South Ryannville",
+          "addressRegion": "Alaska",
+          "postalCode": "85791",
+          "addressCountry": "Poland"
+        },
+        "email": "Raymundo_Hodkiewicz@yahoo.com",
+        "phoneNumber": "228-474-2165 x665"
+      },
+      {
+        "@context": [
+          "https://w3id.org/traceability/v1"
+        ],
+        "type": "Organization",
+        "name": "Orn Group",
+        "description": "Phased coherent pricing structure",
+        "address": {
+          "type": "PostalAddress",
+          "streetAddress": "616 Marques Mill",
+          "addressLocality": "Lemkeshire",
+          "addressRegion": "Oregon",
+          "postalCode": "10226-9002",
+          "addressCountry": "Nigeria"
+        },
+        "email": "Kyler_Kris@hotmail.com",
+        "phoneNumber": "1-763-272-9022 x4456"
+      },
+      {
+        "@context": [
+          "https://w3id.org/traceability/v1"
+        ],
+        "type": "Organization",
+        "name": "Ernser, Lang and Herzog",
+        "description": "Synchronised intermediate interface",
+        "address": {
+          "type": "PostalAddress",
+          "streetAddress": "65406 O'Connell Light",
+          "addressLocality": "Kiehnberg",
+          "addressRegion": "Indiana",
+          "postalCode": "66751-4608",
+          "addressCountry": "Eritrea"
+        },
+        "email": "Wilton.Grady46@yahoo.com",
+        "phoneNumber": "1-878-785-3627"
+      }
+    ],
+    "schema": {
+      "$id": "https://w3id.org/traceability/schemas/Entity.json",
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "$comment": "{\"term\": \"Entity\", \"@id\": \"https://w3id.org/traceability/Entity\"}",
+      "title": "Entity",
+      "description": "A person or organization.",
+      "anyOf": [
+        {
+          "$ref": "https://w3id.org/traceability/schemas/Person.json"
+        },
+        {
+          "$ref": "https://w3id.org/traceability/schemas/Organization.json"
+        }
+      ],
       "examples": []
     }
   },
@@ -833,19 +1511,6 @@
             "type": "Observation",
             "property": {
               "type": "MechanicalProperty",
-              "identifier": "ISO 148",
-              "name": "Charpy Impact Strength Test",
-              "description": "ISO 148-1:2016 specifies the Charpy (V-notch and U-notch) pendulum impact test method for determining the energy absorbed in an impact test of metallic materials. This part of ISO 148 does not cover instrumented impact testing, which is specified in ISO 14556."
-            },
-            "measurement": {
-              "value": "24.720",
-              "unitCode": "B13"
-            }
-          },
-          {
-            "type": "Observation",
-            "property": {
-              "type": "MechanicalProperty",
               "identifier": "ISO 3738",
               "name": "Rockwell Hardness Test (Scale A)",
               "description": "The Rockwell hardness test is an empirical indentation hardness test that can provide useful information about metallic materials."
@@ -853,196 +1518,6 @@
             "measurement": {
               "value": "00.00",
               "unitCode": "UNKNOWN"
-            }
-          },
-          {
-            "type": "Observation",
-            "property": {
-              "type": "ChemicalProperty",
-              "name": "Nihonium",
-              "formula": "Nh"
-            },
-            "measurement": {
-              "value": "00.00",
-              "unitCode": "UNKNOWN"
-            }
-          },
-          {
-            "type": "Observation",
-            "property": {
-              "type": "MechanicalProperty",
-              "identifier": "ISO 148",
-              "name": "Charpy Impact Strength Test",
-              "description": "ISO 148-1:2016 specifies the Charpy (V-notch and U-notch) pendulum impact test method for determining the energy absorbed in an impact test of metallic materials. This part of ISO 148 does not cover instrumented impact testing, which is specified in ISO 14556."
-            },
-            "measurement": {
-              "value": "66.711",
-              "unitCode": "B13"
-            }
-          },
-          {
-            "type": "Observation",
-            "property": {
-              "type": "ChemicalProperty",
-              "name": "Thulium",
-              "formula": "Tm",
-              "inchi": "InChI=1S/Tm",
-              "inchikey": "FRNOGLGSGLTDKL-UHFFFAOYSA-N"
-            },
-            "measurement": {
-              "value": "31.503",
-              "unitCode": "P1"
-            }
-          },
-          {
-            "type": "Observation",
-            "property": {
-              "type": "MechanicalProperty",
-              "identifier": "ISO 3738",
-              "name": "Rockwell Hardness Test (Scale A)",
-              "description": "The Rockwell hardness test is an empirical indentation hardness test that can provide useful information about metallic materials."
-            },
-            "measurement": {
-              "value": "00.00",
-              "unitCode": "UNKNOWN"
-            }
-          },
-          {
-            "type": "Observation",
-            "property": {
-              "type": "MechanicalProperty",
-              "identifier": "ISO 1352",
-              "name": "Torque-controlled fatigue testing",
-              "description": "ISO 1352:2011 specifies the conditions for performing torsional, constant-amplitude, nominally elastic stress fatigue tests on metallic specimens without deliberately introducing stress concentrations. The tests are carried out at ambient temperature (ideally at between 10 °C and 35 °C) in air by applying a pure couple to the specimen about its longitudinal axis."
-            },
-            "measurement": {
-              "value": "00.00",
-              "unitCode": "UNKNOWN"
-            }
-          },
-          {
-            "type": "Observation",
-            "property": {
-              "type": "MechanicalProperty",
-              "identifier": "ISO 3738",
-              "name": "Rockwell Hardness Test (Scale A)",
-              "description": "The Rockwell hardness test is an empirical indentation hardness test that can provide useful information about metallic materials."
-            },
-            "measurement": {
-              "value": "00.00",
-              "unitCode": "UNKNOWN"
-            }
-          },
-          {
-            "type": "Observation",
-            "property": {
-              "type": "ChemicalProperty",
-              "name": "Boron",
-              "formula": "B",
-              "inchi": "InChI=1S/B",
-              "inchikey": "ZOXJGFHDIHLPTG-UHFFFAOYSA-N"
-            },
-            "measurement": {
-              "value": "68.497",
-              "unitCode": "P1"
-            }
-          }
-        ]
-      },
-      {
-        "@context": [
-          "https://w3id.org/traceability/v1"
-        ],
-        "type": "InspectionReport",
-        "observation": [
-          {
-            "type": "Observation",
-            "property": {
-              "type": "ChemicalProperty",
-              "name": "Cesium",
-              "formula": "Cs",
-              "inchi": "InChI=1S/Cs",
-              "inchikey": "TVFDJXOCXUVLDH-UHFFFAOYSA-N"
-            },
-            "measurement": {
-              "value": "32.812",
-              "unitCode": "P1"
-            }
-          },
-          {
-            "type": "Observation",
-            "property": {
-              "type": "ChemicalProperty",
-              "name": "Antimony",
-              "formula": "Sb",
-              "inchi": "InChI=1S/Sb",
-              "inchikey": "WATWJIUSRGPENY-UHFFFAOYSA-N"
-            },
-            "measurement": {
-              "value": "40.179",
-              "unitCode": "P1"
-            }
-          },
-          {
-            "type": "Observation",
-            "property": {
-              "type": "ChemicalProperty",
-              "name": "Selenium",
-              "formula": "Se",
-              "inchi": "InChI=1S/Se",
-              "inchikey": "BUGBHKTXTAQXES-UHFFFAOYSA-N"
-            },
-            "measurement": {
-              "value": "3.3154",
-              "unitCode": "P1"
-            }
-          },
-          {
-            "type": "Observation",
-            "property": {
-              "type": "ChemicalProperty",
-              "name": "Nihonium",
-              "formula": "Nh"
-            },
-            "measurement": {
-              "value": "00.00",
-              "unitCode": "UNKNOWN"
-            }
-          },
-          {
-            "type": "Observation",
-            "property": {
-              "type": "ChemicalProperty",
-              "name": "Scandium",
-              "formula": "Sc",
-              "inchi": "InChI=1S/Sc",
-              "inchikey": "SIXSYDAISGFNSX-UHFFFAOYSA-N"
-            },
-            "measurement": {
-              "value": "23.694",
-              "unitCode": "P1"
-            }
-          }
-        ]
-      },
-      {
-        "@context": [
-          "https://w3id.org/traceability/v1"
-        ],
-        "type": "InspectionReport",
-        "observation": [
-          {
-            "type": "Observation",
-            "property": {
-              "type": "ChemicalProperty",
-              "name": "Indium",
-              "formula": "In",
-              "inchi": "InChI=1S/In",
-              "inchikey": "APFVFJFRJDLVQX-UHFFFAOYSA-N"
-            },
-            "measurement": {
-              "value": "33.267",
-              "unitCode": "P1"
             }
           },
           {
@@ -1055,7 +1530,7 @@
               "inchikey": "KLMCZVJOEAUDNE-UHFFFAOYSA-N"
             },
             "measurement": {
-              "value": "28.949",
+              "value": "100.00",
               "unitCode": "P1"
             }
           },
@@ -1063,14 +1538,12 @@
             "type": "Observation",
             "property": {
               "type": "ChemicalProperty",
-              "name": "Krypton",
-              "formula": "Kr",
-              "inchi": "InChI=1S/Kr",
-              "inchikey": "DNNSSWSSYDEUBZ-UHFFFAOYSA-N"
+              "name": "Seaborgium",
+              "formula": "Sg"
             },
             "measurement": {
-              "value": "37.783",
-              "unitCode": "P1"
+              "value": "00.00",
+              "unitCode": "UNKNOWN"
             }
           },
           {
@@ -1082,7 +1555,28 @@
               "description": "ISO 180 defines the method used for pendulums to determine the impact resistance of a plastic specimen when supported in a cantilever configuration. Test results are used to evaluate the resilience of materials, typically plastics."
             },
             "measurement": {
-              "value": "92.316",
+              "value": "50.487",
+              "unitCode": "B13"
+            }
+          }
+        ]
+      },
+      {
+        "@context": [
+          "https://w3id.org/traceability/v1"
+        ],
+        "type": "InspectionReport",
+        "observation": [
+          {
+            "type": "Observation",
+            "property": {
+              "type": "MechanicalProperty",
+              "identifier": "ISO 180",
+              "name": "Izod Impact Strength Test",
+              "description": "ISO 180 defines the method used for pendulums to determine the impact resistance of a plastic specimen when supported in a cantilever configuration. Test results are used to evaluate the resilience of materials, typically plastics."
+            },
+            "measurement": {
+              "value": "62.515",
               "unitCode": "B13"
             }
           },
@@ -1090,13 +1584,63 @@
             "type": "Observation",
             "property": {
               "type": "MechanicalProperty",
-              "identifier": "ISO 1352",
-              "name": "Torque-controlled fatigue testing",
-              "description": "ISO 1352:2011 specifies the conditions for performing torsional, constant-amplitude, nominally elastic stress fatigue tests on metallic specimens without deliberately introducing stress concentrations. The tests are carried out at ambient temperature (ideally at between 10 °C and 35 °C) in air by applying a pure couple to the specimen about its longitudinal axis."
+              "identifier": "ISO 148",
+              "name": "Charpy Impact Strength Test",
+              "description": "ISO 148-1:2016 specifies the Charpy (V-notch and U-notch) pendulum impact test method for determining the energy absorbed in an impact test of metallic materials. This part of ISO 148 does not cover instrumented impact testing, which is specified in ISO 14556."
             },
             "measurement": {
-              "value": "00.00",
-              "unitCode": "UNKNOWN"
+              "value": "96.659",
+              "unitCode": "B13"
+            }
+          },
+          {
+            "type": "Observation",
+            "property": {
+              "type": "ChemicalProperty",
+              "name": "Cobalt",
+              "formula": "Co",
+              "inchi": "InChI=1S/Co",
+              "inchikey": "GUTLYIVDDKVIGB-UHFFFAOYSA-N"
+            },
+            "measurement": {
+              "value": "100.00",
+              "unitCode": "P1"
+            }
+          }
+        ]
+      },
+      {
+        "@context": [
+          "https://w3id.org/traceability/v1"
+        ],
+        "type": "InspectionReport",
+        "observation": [
+          {
+            "type": "Observation",
+            "property": {
+              "type": "ChemicalProperty",
+              "name": "Xenon",
+              "formula": "Xe",
+              "inchi": "InChI=1S/Xe",
+              "inchikey": "FHNFHKCVQCLJFQ-UHFFFAOYSA-N"
+            },
+            "measurement": {
+              "value": "15.885",
+              "unitCode": "P1"
+            }
+          },
+          {
+            "type": "Observation",
+            "property": {
+              "type": "ChemicalProperty",
+              "name": "Gold",
+              "formula": "Au",
+              "inchi": "InChI=1S/Au",
+              "inchikey": "PCHJSUWPFVWCPO-UHFFFAOYSA-N"
+            },
+            "measurement": {
+              "value": "3.1246",
+              "unitCode": "P1"
             }
           },
           {
@@ -1115,14 +1659,69 @@
           {
             "type": "Observation",
             "property": {
-              "type": "MechanicalProperty",
-              "identifier": "ISO 180",
-              "name": "Izod Impact Strength Test",
-              "description": "ISO 180 defines the method used for pendulums to determine the impact resistance of a plastic specimen when supported in a cantilever configuration. Test results are used to evaluate the resilience of materials, typically plastics."
+              "type": "ChemicalProperty",
+              "name": "Sodium",
+              "formula": "Na",
+              "inchi": "InChI=1S/Na",
+              "inchikey": "KEAYESYHFKHZAL-UHFFFAOYSA-N"
             },
             "measurement": {
-              "value": "78.265",
-              "unitCode": "B13"
+              "value": "28.043",
+              "unitCode": "P1"
+            }
+          },
+          {
+            "type": "Observation",
+            "property": {
+              "type": "MechanicalProperty",
+              "identifier": "ISO 3738",
+              "name": "Rockwell Hardness Test (Scale A)",
+              "description": "The Rockwell hardness test is an empirical indentation hardness test that can provide useful information about metallic materials."
+            },
+            "measurement": {
+              "value": "00.00",
+              "unitCode": "UNKNOWN"
+            }
+          },
+          {
+            "type": "Observation",
+            "property": {
+              "type": "ChemicalProperty",
+              "name": "Aluminium",
+              "formula": "Al",
+              "inchi": "InChI=1S/Al",
+              "inchikey": "XAGFODPZIPBFFR-UHFFFAOYSA-N"
+            },
+            "measurement": {
+              "value": "39.861",
+              "unitCode": "P1"
+            }
+          },
+          {
+            "type": "Observation",
+            "property": {
+              "type": "ChemicalProperty",
+              "name": "Radon",
+              "formula": "Rn",
+              "inchi": "InChI=1S/Rn",
+              "inchikey": "SYUHGPGVQRZVTB-UHFFFAOYSA-N"
+            },
+            "measurement": {
+              "value": "13.087",
+              "unitCode": "P1"
+            }
+          },
+          {
+            "type": "Observation",
+            "property": {
+              "type": "MechanicalProperty",
+              "identifier": "ISO 1352",
+              "name": "Torque-controlled fatigue testing",
+              "description": "ISO 1352:2011 specifies the conditions for performing torsional, constant-amplitude, nominally elastic stress fatigue tests on metallic specimens without deliberately introducing stress concentrations. The tests are carried out at ambient temperature (ideally at between 10 °C and 35 °C) in air by applying a pure couple to the specimen about its longitudinal axis."
+            },
+            "measurement": {
+              "value": "00.00",
+              "unitCode": "UNKNOWN"
             }
           }
         ]
@@ -1173,10 +1772,10 @@
     "title": "Inspector",
     "description": "Information on the person performing an inspection",
     "classProperties": {
-      "https://schema.org/Person": {
+      "https://w3id.org/traceability/schemas/Person.json": {
         "$comment": {
           "term": "person",
-          "@id": "https://schema.org/Person"
+          "@id": "https://w3id.org/traceability/schemas/Person.json"
         },
         "title": "Person",
         "description": "Person doing the inspection."
@@ -1197,17 +1796,34 @@
           "https://w3id.org/traceability/v1"
         ],
         "type": "Inspector",
-        "person": "Julius Hartmann",
+        "person": {
+          "type": "Person",
+          "firstName": "Evie",
+          "lastName": "Kuhic",
+          "email": "Minnie29@yahoo.com",
+          "phoneNumber": "(377) 777-0267 x195",
+          "worksFor": {
+            "type": "Organization",
+            "name": "Hane - Lang",
+            "description": "Programmable directional software",
+            "address": {
+              "type": "PostalAddress",
+              "streetAddress": "9567 Wunsch Square",
+              "addressLocality": "North Jade",
+              "addressRegion": "Alaska",
+              "postalCode": "74640",
+              "addressCountry": "Grenada"
+            },
+            "email": "Koby58@gmail.com",
+            "phoneNumber": "377-887-6127 x3853"
+          },
+          "jobTitle": "Dynamic Response Technician"
+        },
         "credential": [
           {
             "type": "Credential",
-            "credentialCategory": "Corporate Research Designer",
-            "credentialValue": "Architect"
-          },
-          {
-            "type": "Credential",
-            "credentialCategory": "International Security Producer",
-            "credentialValue": "Producer"
+            "credentialCategory": "Global Identity Administrator",
+            "credentialValue": "Agent"
           }
         ]
       },
@@ -1216,22 +1832,34 @@
           "https://w3id.org/traceability/v1"
         ],
         "type": "Inspector",
-        "person": "Sheryl Heidenreich",
+        "person": {
+          "type": "Person",
+          "firstName": "Horace",
+          "lastName": "Bashirian",
+          "email": "Carlee89@gmail.com",
+          "phoneNumber": "227.753.9606 x7274",
+          "worksFor": {
+            "type": "Organization",
+            "name": "Casper - Hintz",
+            "description": "Grass-roots next generation info-mediaries",
+            "address": {
+              "type": "PostalAddress",
+              "streetAddress": "51258 Kub Courts",
+              "addressLocality": "Port Lilianabury",
+              "addressRegion": "Wyoming",
+              "postalCode": "38565",
+              "addressCountry": "Namibia"
+            },
+            "email": "Gaylord26@yahoo.com",
+            "phoneNumber": "911-751-7313"
+          },
+          "jobTitle": "Corporate Quality Designer"
+        },
         "credential": [
           {
             "type": "Credential",
-            "credentialCategory": "Direct Group Analyst",
-            "credentialValue": "Liaison"
-          },
-          {
-            "type": "Credential",
-            "credentialCategory": "Chief Communications Coordinator",
-            "credentialValue": "Strategist"
-          },
-          {
-            "type": "Credential",
-            "credentialCategory": "Corporate Paradigm Assistant",
-            "credentialValue": "Planner"
+            "credentialCategory": "Legacy Mobility Designer",
+            "credentialValue": "Coordinator"
           }
         ]
       },
@@ -1240,17 +1868,44 @@
           "https://w3id.org/traceability/v1"
         ],
         "type": "Inspector",
-        "person": "Erin Considine III",
+        "person": {
+          "type": "Person",
+          "firstName": "Hester",
+          "lastName": "Bahringer",
+          "email": "Bria_Mante1@gmail.com",
+          "phoneNumber": "(593) 911-0654 x485",
+          "worksFor": {
+            "type": "Organization",
+            "name": "Hamill LLC",
+            "description": "Persevering content-based implementation",
+            "address": {
+              "type": "PostalAddress",
+              "streetAddress": "601 Hirthe Circles",
+              "addressLocality": "Friesenport",
+              "addressRegion": "Montana",
+              "postalCode": "10655-8812",
+              "addressCountry": "Paraguay"
+            },
+            "email": "Loma_Carroll85@yahoo.com",
+            "phoneNumber": "593-975-7547 x26115"
+          },
+          "jobTitle": "Chief Identity Assistant"
+        },
         "credential": [
           {
             "type": "Credential",
-            "credentialCategory": "Dynamic Functionality Manager",
-            "credentialValue": "Strategist"
+            "credentialCategory": "Human Optimization Officer",
+            "credentialValue": "Assistant"
           },
           {
             "type": "Credential",
-            "credentialCategory": "Corporate Research Producer",
-            "credentialValue": "Analyst"
+            "credentialCategory": "Regional Functionality Agent",
+            "credentialValue": "Executive"
+          },
+          {
+            "type": "Credential",
+            "credentialCategory": "District Group Administrator",
+            "credentialValue": "Coordinator"
           }
         ]
       }
@@ -1277,10 +1932,10 @@
           ]
         },
         "person": {
-          "$comment": "{\"term\": \"person\", \"@id\": \"https://schema.org/Person\"}",
+          "$comment": "{\"term\": \"person\", \"@id\": \"https://w3id.org/traceability/schemas/Person.json\"}",
           "title": "Person",
           "description": "Person doing the inspection.",
-          "type": "string"
+          "$ref": "https://w3id.org/traceability/schemas/Person.json"
         },
         "credential": {
           "$comment": "{\"term\": \"credential\", \"@id\": \"https://schema.org/ItemList\", \"@type\": \"https://schema.org/ItemList\"}",
@@ -1585,14 +2240,30 @@
         ],
         "type": "Observation",
         "property": {
-          "type": "ChemicalProperty",
-          "name": "Titanium",
-          "formula": "Ti",
-          "inchi": "InChI=1S/Ti",
-          "inchikey": "RTAQQCXQSZGOHL-UHFFFAOYSA-N"
+          "type": "MechanicalProperty",
+          "identifier": "ISO 180",
+          "name": "Izod Impact Strength Test",
+          "description": "ISO 180 defines the method used for pendulums to determine the impact resistance of a plastic specimen when supported in a cantilever configuration. Test results are used to evaluate the resilience of materials, typically plastics."
         },
         "measurement": {
-          "value": "36.424",
+          "value": "39.819",
+          "unitCode": "B13"
+        }
+      },
+      {
+        "@context": [
+          "https://w3id.org/traceability/v1"
+        ],
+        "type": "Observation",
+        "property": {
+          "type": "ChemicalProperty",
+          "name": "Copper",
+          "formula": "Cu",
+          "inchi": "InChI=1S/Cu",
+          "inchikey": "RYGMFSIKBFXOCR-UHFFFAOYSA-N"
+        },
+        "measurement": {
+          "value": "86.107",
           "unitCode": "P1"
         }
       },
@@ -1603,30 +2274,13 @@
         "type": "Observation",
         "property": {
           "type": "ChemicalProperty",
-          "name": "Cadmium",
-          "formula": "Cd",
-          "inchi": "InChI=1S/Cd",
-          "inchikey": "BDOSMKKIYDKNTQ-UHFFFAOYSA-N"
+          "name": "Chromium",
+          "formula": "Cr",
+          "inchi": "InChI=1S/Cr",
+          "inchikey": "VYZAMTAEIAYCRO-UHFFFAOYSA-N"
         },
         "measurement": {
-          "value": "8.747",
-          "unitCode": "P1"
-        }
-      },
-      {
-        "@context": [
-          "https://w3id.org/traceability/v1"
-        ],
-        "type": "Observation",
-        "property": {
-          "type": "ChemicalProperty",
-          "name": "Lanthanum",
-          "formula": "La",
-          "inchi": "InChI=1S/La",
-          "inchikey": "FZLIPJUXYLNCLC-UHFFFAOYSA-N"
-        },
-        "measurement": {
-          "value": "67.285",
+          "value": "83.190",
           "unitCode": "P1"
         }
       }
@@ -1663,6 +2317,765 @@
           "title": "Measured Value",
           "description": "The measurement of an Observation.",
           "$ref": "https://w3id.org/traceability/schemas/MeasuredValue.json"
+        }
+      },
+      "additionalProperties": false,
+      "examples": []
+    }
+  },
+  "https://schema.org/Organization": {
+    "$id": "https://w3id.org/traceability/schemas/Organization.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$comment": {
+      "term": "Organization",
+      "@id": "https://schema.org/Organization"
+    },
+    "title": "Organization",
+    "description": "An organization such as a corporation, firm, club, etc.",
+    "classProperties": {
+      "https://schema.org/name": {
+        "$comment": {
+          "term": "name",
+          "@id": "https://schema.org/name"
+        },
+        "title": "Name",
+        "description": "Name of the organization."
+      },
+      "https://schema.org/description": {
+        "$comment": {
+          "term": "description",
+          "@id": "https://schema.org/description"
+        },
+        "title": "Description",
+        "description": "Description of the company."
+      },
+      "https://schema.org/PostalAddress": {
+        "$comment": {
+          "term": "address",
+          "@id": "https://schema.org/PostalAddress"
+        },
+        "title": "Postal Address",
+        "description": "The postal address for an organization or place."
+      },
+      "https://schema.org/email": {
+        "$comment": {
+          "term": "email",
+          "@id": "https://schema.org/email"
+        },
+        "title": "Email Address",
+        "description": "Organization's primary email address."
+      },
+      "https://schema.org/telephone": {
+        "$comment": {
+          "term": "phoneNumber",
+          "@id": "https://schema.org/telephone"
+        },
+        "title": "Phone Number",
+        "description": "Organization's contact phone number."
+      }
+    },
+    "examples": [
+      {
+        "@context": [
+          "https://w3id.org/traceability/v1"
+        ],
+        "type": "Organization",
+        "name": "Haley LLC",
+        "description": "Vision-oriented mission-critical local area network",
+        "address": {
+          "type": "PostalAddress",
+          "streetAddress": "4774 Hessel Viaduct",
+          "addressLocality": "Koelpinland",
+          "addressRegion": "West Virginia",
+          "postalCode": "10929-2431",
+          "addressCountry": "Gibraltar"
+        },
+        "email": "Garnet.Padberg@hotmail.com",
+        "phoneNumber": "1-574-531-2090 x69016"
+      },
+      {
+        "@context": [
+          "https://w3id.org/traceability/v1"
+        ],
+        "type": "Organization",
+        "name": "Mitchell, Hackett and McGlynn",
+        "description": "Focused systemic software",
+        "address": {
+          "type": "PostalAddress",
+          "streetAddress": "56339 Labadie Brooks",
+          "addressLocality": "Lake Guadalupestad",
+          "addressRegion": "Nevada",
+          "postalCode": "50842",
+          "addressCountry": "Antarctica (the territory South of 60 deg S)"
+        },
+        "email": "Brody.Stanton68@yahoo.com",
+        "phoneNumber": "612.369.8465 x805"
+      },
+      {
+        "@context": [
+          "https://w3id.org/traceability/v1"
+        ],
+        "type": "Organization",
+        "name": "Haley LLC",
+        "description": "Total leading edge conglomeration",
+        "address": {
+          "type": "PostalAddress",
+          "streetAddress": "907 Mohammad Garden",
+          "addressLocality": "North Ricky",
+          "addressRegion": "Oklahoma",
+          "postalCode": "04127-9990",
+          "addressCountry": "Maldives"
+        },
+        "email": "Lavon_Swift@hotmail.com",
+        "phoneNumber": "(748) 987-7129 x5637"
+      }
+    ],
+    "schema": {
+      "$id": "https://w3id.org/traceability/schemas/Organization.json",
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "$comment": "{\"term\": \"Organization\", \"@id\": \"https://schema.org/Organization\"}",
+      "title": "Organization",
+      "description": "An organization such as a corporation, firm, club, etc.",
+      "type": "object",
+      "properties": {
+        "@context": {
+          "type": "array"
+        },
+        "type": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array"
+            }
+          ]
+        },
+        "name": {
+          "$comment": "{\"term\": \"name\", \"@id\": \"https://schema.org/name\"}",
+          "title": "Name",
+          "description": "Name of the organization.",
+          "type": "string"
+        },
+        "description": {
+          "$comment": "{\"term\": \"description\", \"@id\": \"https://schema.org/description\"}",
+          "title": "Description",
+          "description": "Description of the company.",
+          "type": "string"
+        },
+        "address": {
+          "$comment": "{\"term\": \"address\", \"@id\": \"https://schema.org/PostalAddress\"}",
+          "title": "Postal Address",
+          "description": "The postal address for an organization or place.",
+          "$ref": "https://w3id.org/traceability/schemas/PostalAddress.json"
+        },
+        "email": {
+          "$comment": "{\"term\": \"email\", \"@id\": \"https://schema.org/email\"}",
+          "title": "Email Address",
+          "description": "Organization's primary email address.",
+          "type": "string"
+        },
+        "phoneNumber": {
+          "$comment": "{\"term\": \"phoneNumber\", \"@id\": \"https://schema.org/telephone\"}",
+          "title": "Phone Number",
+          "description": "Organization's contact phone number.",
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "examples": []
+    }
+  },
+  "https://schema.org/ParcelDelivery": {
+    "$id": "https://w3id.org/traceability/schemas/ParcelDelivery.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$comment": {
+      "term": "ParcelDelivery",
+      "@id": "https://schema.org/ParcelDelivery"
+    },
+    "title": "Parcel Delivery",
+    "description": "Details on a shipment or delivery.",
+    "classProperties": {
+      "https://schema.org/deliveryAddress": {
+        "$comment": {
+          "term": "deliveryAddress",
+          "@id": "https://schema.org/deliveryAddress"
+        },
+        "title": "Delivery Address",
+        "description": "Address to which the shipment is being sent."
+      },
+      "https://schema.org/originAddress": {
+        "$comment": {
+          "term": "originAddress",
+          "@id": "https://schema.org/originAddress"
+        },
+        "title": "Origin Address",
+        "description": "Address from where the shipment was sent."
+      },
+      "https://schema.org/trackingNumber": {
+        "$comment": {
+          "term": "trackingNumber",
+          "@id": "https://schema.org/trackingNumber"
+        },
+        "title": "Tracking Number",
+        "description": "Shipper tracking number."
+      },
+      "https://schema.org/ItemList": {
+        "$comment": {
+          "term": "products",
+          "@id": "https://schema.org/ItemList",
+          "@type": "https://schema.org/ItemList"
+        },
+        "title": "Product List",
+        "description": "List of Products"
+      }
+    },
+    "examples": [
+      {
+        "@context": [
+          "https://w3id.org/traceability/v1"
+        ],
+        "type": "ParcelDelivery",
+        "deliveryAddress": {
+          "type": "PostalAddress",
+          "organizationName": "Veum - O'Kon",
+          "streetAddress": "95908 Corwin Vista",
+          "addressLocality": "Lake Jayde",
+          "addressRegion": "Maryland",
+          "postalCode": "45737-5267",
+          "addressCountry": "Virgin Islands, U.S."
+        },
+        "originAddress": {
+          "type": "PostalAddress",
+          "organizationName": "Mraz, Keeling and Huels",
+          "streetAddress": "92784 Rice Roads",
+          "addressLocality": "Keeblershire",
+          "addressRegion": "Wyoming",
+          "postalCode": "28932",
+          "addressCountry": "Hungary"
+        },
+        "trackingNumber": "401546314975",
+        "products": [
+          {
+            "type": "Product",
+            "manufacturer": {
+              "type": "Person",
+              "firstName": "Keith",
+              "lastName": "Skiles",
+              "email": "Jon.Stiedemann41@yahoo.com",
+              "phoneNumber": "1-787-298-3130 x3469",
+              "worksFor": {
+                "type": "Organization",
+                "name": "King, Miller and Legros",
+                "description": "Right-sized tertiary definition",
+                "address": {
+                  "type": "PostalAddress",
+                  "streetAddress": "25205 Stokes Squares",
+                  "addressLocality": "West Rae",
+                  "addressRegion": "Delaware",
+                  "postalCode": "29172",
+                  "addressCountry": "Bouvet Island (Bouvetoya)"
+                },
+                "email": "Derick90@hotmail.com",
+                "phoneNumber": "715.690.4367 x8288"
+              },
+              "jobTitle": "Internal Usability Administrator"
+            },
+            "name": "Gorgeous Soft Tuna",
+            "description": "Ergonomic executive chair upholstered in bonded black leather and PVC padded seat and back for all-day comfort and support",
+            "sizeOrAmount": {
+              "type": "QuantitativeValue",
+              "unitCode": "hg/ha",
+              "value": "566"
+            },
+            "weight": {
+              "type": "QuantitativeValue",
+              "unitCode": "hg/ha",
+              "value": "7222"
+            },
+            "sku": "165788693926"
+          },
+          {
+            "type": "Product",
+            "manufacturer": {
+              "type": "Organization",
+              "name": "Keeling, Watsica and Lindgren",
+              "description": "Seamless intangible secured line",
+              "address": {
+                "type": "PostalAddress",
+                "streetAddress": "80724 Stephanie Points",
+                "addressLocality": "New Joesphburgh",
+                "addressRegion": "New Jersey",
+                "postalCode": "02802",
+                "addressCountry": "Cote d'Ivoire"
+              },
+              "email": "Ellen37@gmail.com",
+              "phoneNumber": "537.948.1856"
+            },
+            "name": "Gorgeous Fresh Chips",
+            "description": "Andy shoes are designed to keeping in mind durability as well as trends, the most stylish range of shoes & sandals",
+            "sizeOrAmount": {
+              "type": "QuantitativeValue",
+              "unitCode": "hg/ha",
+              "value": "7981"
+            },
+            "weight": {
+              "type": "QuantitativeValue",
+              "unitCode": "hg/ha",
+              "value": "4651"
+            },
+            "sku": "801948730210"
+          },
+          {
+            "type": "Product",
+            "manufacturer": {
+              "type": "Person",
+              "firstName": "Hunter",
+              "lastName": "Torphy",
+              "email": "Faye19@hotmail.com",
+              "phoneNumber": "830.908.0086 x33230",
+              "worksFor": {
+                "type": "Organization",
+                "name": "Dibbert - Rohan",
+                "description": "Future-proofed asymmetric ability",
+                "address": {
+                  "type": "PostalAddress",
+                  "streetAddress": "664 Welch Mountain",
+                  "addressLocality": "Hettingerton",
+                  "addressRegion": "Connecticut",
+                  "postalCode": "04805-8213",
+                  "addressCountry": "Cote d'Ivoire"
+                },
+                "email": "Brayan_Mitchell@yahoo.com",
+                "phoneNumber": "331-973-3810"
+              },
+              "jobTitle": "District Functionality Coordinator"
+            },
+            "name": "Ergonomic Metal Cheese",
+            "description": "The slim & simple Maple Gaming Keyboard from Dev Byte comes with a sleek body and 7- Color RGB LED Back-lighting for smart functionality",
+            "sizeOrAmount": {
+              "type": "QuantitativeValue",
+              "unitCode": "hg/ha",
+              "value": "6182"
+            },
+            "weight": {
+              "type": "QuantitativeValue",
+              "unitCode": "hg/ha",
+              "value": "3624"
+            },
+            "sku": "516906568294"
+          }
+        ]
+      },
+      {
+        "@context": [
+          "https://w3id.org/traceability/v1"
+        ],
+        "type": "ParcelDelivery",
+        "deliveryAddress": {
+          "type": "PostalAddress",
+          "organizationName": "Hickle, Green and Gulgowski",
+          "streetAddress": "6608 Lindgren Cliffs",
+          "addressLocality": "Hagenesfurt",
+          "addressRegion": "North Dakota",
+          "postalCode": "23678-7332",
+          "addressCountry": "Bermuda"
+        },
+        "originAddress": {
+          "type": "PostalAddress",
+          "organizationName": "Bogisich, Collins and Murazik",
+          "streetAddress": "1952 Noble Ville",
+          "addressLocality": "South Roel",
+          "addressRegion": "Ohio",
+          "postalCode": "40883-1681",
+          "addressCountry": "Hungary"
+        },
+        "trackingNumber": "226798274110",
+        "products": [
+          {
+            "type": "Product",
+            "manufacturer": {
+              "type": "Person",
+              "firstName": "Diego",
+              "lastName": "Kub",
+              "email": "Kory.Osinski91@yahoo.com",
+              "phoneNumber": "204-936-1185 x605",
+              "worksFor": {
+                "type": "Organization",
+                "name": "Bogisich, Bode and Grimes",
+                "description": "Public-key user-facing middleware",
+                "address": {
+                  "type": "PostalAddress",
+                  "streetAddress": "2686 Harber Forks",
+                  "addressLocality": "Luettgenchester",
+                  "addressRegion": "New Mexico",
+                  "postalCode": "42755-7680",
+                  "addressCountry": "Saint Lucia"
+                },
+                "email": "Deshawn.Reinger85@yahoo.com",
+                "phoneNumber": "579-442-4262"
+              },
+              "jobTitle": "District Markets Assistant"
+            },
+            "name": "Rustic Metal Mouse",
+            "description": "Andy shoes are designed to keeping in mind durability as well as trends, the most stylish range of shoes & sandals",
+            "sizeOrAmount": {
+              "type": "QuantitativeValue",
+              "unitCode": "hg/ha",
+              "value": "6470"
+            },
+            "weight": {
+              "type": "QuantitativeValue",
+              "unitCode": "hg/ha",
+              "value": "3983"
+            },
+            "sku": "128267951770"
+          }
+        ]
+      },
+      {
+        "@context": [
+          "https://w3id.org/traceability/v1"
+        ],
+        "type": "ParcelDelivery",
+        "deliveryAddress": {
+          "type": "PostalAddress",
+          "organizationName": "White Inc",
+          "streetAddress": "9784 Leffler Dam",
+          "addressLocality": "New Diego",
+          "addressRegion": "Oregon",
+          "postalCode": "47183-5990",
+          "addressCountry": "Tokelau"
+        },
+        "originAddress": {
+          "type": "PostalAddress",
+          "organizationName": "Koepp LLC",
+          "streetAddress": "7244 Kunde Glens",
+          "addressLocality": "Wayneborough",
+          "addressRegion": "Louisiana",
+          "postalCode": "73186",
+          "addressCountry": "Faroe Islands"
+        },
+        "trackingNumber": "210537393926",
+        "products": [
+          {
+            "type": "Product",
+            "manufacturer": {
+              "type": "Organization",
+              "name": "Connelly, Corwin and Rath",
+              "description": "Versatile homogeneous time-frame",
+              "address": {
+                "type": "PostalAddress",
+                "streetAddress": "37752 Diana Land",
+                "addressLocality": "Bergnaummouth",
+                "addressRegion": "Alaska",
+                "postalCode": "80687-0610",
+                "addressCountry": "Kuwait"
+              },
+              "email": "Vincenza.Borer@gmail.com",
+              "phoneNumber": "701-997-6375 x4126"
+            },
+            "name": "Unbranded Steel Ball",
+            "description": "The automobile layout consists of a front-engine design, with transaxle-type transmissions mounted at the rear of the engine and four wheel drive",
+            "sizeOrAmount": {
+              "type": "QuantitativeValue",
+              "unitCode": "hg/ha",
+              "value": "9891"
+            },
+            "weight": {
+              "type": "QuantitativeValue",
+              "unitCode": "hg/ha",
+              "value": "2739"
+            },
+            "sku": "405649282369"
+          },
+          {
+            "type": "Product",
+            "manufacturer": {
+              "type": "Person",
+              "firstName": "Junior",
+              "lastName": "Stoltenberg",
+              "email": "Arvel.Stehr@hotmail.com",
+              "phoneNumber": "497-729-3522",
+              "worksFor": {
+                "type": "Organization",
+                "name": "Hayes - Schaden",
+                "description": "Operative needs-based knowledge user",
+                "address": {
+                  "type": "PostalAddress",
+                  "streetAddress": "24041 Liliana Rapid",
+                  "addressLocality": "New Dewayne",
+                  "addressRegion": "Montana",
+                  "postalCode": "59084-5273",
+                  "addressCountry": "Russian Federation"
+                },
+                "email": "Frederic_Stroman39@gmail.com",
+                "phoneNumber": "567.945.4808"
+              },
+              "jobTitle": "Dynamic Research Orchestrator"
+            },
+            "name": "Handcrafted Plastic Chips",
+            "description": "Ergonomic executive chair upholstered in bonded black leather and PVC padded seat and back for all-day comfort and support",
+            "sizeOrAmount": {
+              "type": "QuantitativeValue",
+              "unitCode": "hg/ha",
+              "value": "8212"
+            },
+            "weight": {
+              "type": "QuantitativeValue",
+              "unitCode": "hg/ha",
+              "value": "3592"
+            },
+            "sku": "105269685098"
+          }
+        ]
+      }
+    ],
+    "schema": {
+      "$id": "https://w3id.org/traceability/schemas/ParcelDelivery.json",
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "$comment": "{\"term\": \"ParcelDelivery\", \"@id\": \"https://schema.org/ParcelDelivery\"}",
+      "title": "Parcel Delivery",
+      "description": "Details on a shipment or delivery.",
+      "type": "object",
+      "properties": {
+        "@context": {
+          "type": "array"
+        },
+        "type": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array"
+            }
+          ]
+        },
+        "deliveryAddress": {
+          "$comment": "{\"term\": \"deliveryAddress\", \"@id\": \"https://schema.org/deliveryAddress\"}",
+          "title": "Delivery Address",
+          "description": "Address to which the shipment is being sent.",
+          "$ref": "https://w3id.org/traceability/schemas/PostalAddress.json"
+        },
+        "originAddress": {
+          "$comment": "{\"term\": \"originAddress\", \"@id\": \"https://schema.org/originAddress\"}",
+          "title": "Origin Address",
+          "description": "Address from where the shipment was sent.",
+          "$ref": "https://w3id.org/traceability/schemas/PostalAddress.json"
+        },
+        "trackingNumber": {
+          "$comment": "{\"term\": \"trackingNumber\", \"@id\": \"https://schema.org/trackingNumber\"}",
+          "title": "Tracking Number",
+          "description": "Shipper tracking number.",
+          "type": "string"
+        },
+        "products": {
+          "$comment": "{\"term\": \"products\", \"@id\": \"https://schema.org/ItemList\", \"@type\": \"https://schema.org/ItemList\"}",
+          "title": "Product List",
+          "description": "List of Products",
+          "type": "array"
+        }
+      },
+      "additionalProperties": false,
+      "examples": []
+    }
+  },
+  "https://schema.org/Person": {
+    "$id": "https://w3id.org/traceability/schemas/Person.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$comment": {
+      "term": "Person",
+      "@id": "https://schema.org/Person"
+    },
+    "title": "Person",
+    "description": "A person",
+    "classProperties": {
+      "https://schema.org/givenName": {
+        "$comment": {
+          "term": "firstName",
+          "@id": "https://schema.org/givenName"
+        },
+        "title": "First Name",
+        "description": "Person's first name."
+      },
+      "https://schema.org/familyName": {
+        "$comment": {
+          "term": "lastName",
+          "@id": "https://schema.org/familyName"
+        },
+        "title": "Last Name",
+        "description": "Person's last name."
+      },
+      "https://schema.org/email": {
+        "$comment": {
+          "term": "email",
+          "@id": "https://schema.org/email"
+        },
+        "title": "Person's Email Address",
+        "description": "Person's email address."
+      },
+      "https://schema.org/telephone": {
+        "$comment": {
+          "term": "phoneNumber",
+          "@id": "https://schema.org/telephone"
+        },
+        "title": "Phone Number",
+        "description": "Person's contact phone number."
+      },
+      "https://schema.org/worksFor": {
+        "$comment": {
+          "term": "worksFor",
+          "@id": "https://schema.org/worksFor"
+        },
+        "title": "Works For",
+        "description": "Company which employs the person."
+      },
+      "https://schema.org/jobTitle": {
+        "$comment": {
+          "term": "jobTitle",
+          "@id": "https://schema.org/jobTitle"
+        },
+        "title": "Job Title",
+        "description": "Person's job title."
+      }
+    },
+    "examples": [
+      {
+        "@context": [
+          "https://w3id.org/traceability/v1"
+        ],
+        "type": "Person",
+        "firstName": "Reggie",
+        "lastName": "Swaniawski",
+        "email": "Abbigail_Wintheiser96@yahoo.com",
+        "phoneNumber": "1-669-877-4103",
+        "worksFor": {
+          "type": "Organization",
+          "name": "Rath, Fadel and Von",
+          "description": "Compatible responsive knowledge base",
+          "address": {
+            "type": "PostalAddress",
+            "streetAddress": "49334 Weissnat Curve",
+            "addressLocality": "East Lisandroside",
+            "addressRegion": "South Dakota",
+            "postalCode": "04081",
+            "addressCountry": "Swaziland"
+          },
+          "email": "Isobel_Kihn@hotmail.com",
+          "phoneNumber": "1-941-975-4053 x0265"
+        },
+        "jobTitle": "District Accountability Officer"
+      },
+      {
+        "@context": [
+          "https://w3id.org/traceability/v1"
+        ],
+        "type": "Person",
+        "firstName": "Layla",
+        "lastName": "Wisozk",
+        "email": "Magdalena.Orn@gmail.com",
+        "phoneNumber": "379-636-0905 x53569",
+        "worksFor": {
+          "type": "Organization",
+          "name": "Toy LLC",
+          "description": "Total background initiative",
+          "address": {
+            "type": "PostalAddress",
+            "streetAddress": "304 Jaskolski Spur",
+            "addressLocality": "Kilbacktown",
+            "addressRegion": "Louisiana",
+            "postalCode": "31843-1657",
+            "addressCountry": "Cote d'Ivoire"
+          },
+          "email": "Braden_Kilback18@hotmail.com",
+          "phoneNumber": "1-777-789-8569"
+        },
+        "jobTitle": "Investor Infrastructure Specialist"
+      },
+      {
+        "@context": [
+          "https://w3id.org/traceability/v1"
+        ],
+        "type": "Person",
+        "firstName": "Elliot",
+        "lastName": "Halvorson",
+        "email": "Richard72@hotmail.com",
+        "phoneNumber": "724.861.5735",
+        "worksFor": {
+          "type": "Organization",
+          "name": "Balistreri, Ankunding and Dach",
+          "description": "Persistent asymmetric concept",
+          "address": {
+            "type": "PostalAddress",
+            "streetAddress": "0406 Walter Flats",
+            "addressLocality": "Destiniberg",
+            "addressRegion": "Delaware",
+            "postalCode": "55182",
+            "addressCountry": "South Georgia and the South Sandwich Islands"
+          },
+          "email": "Damaris.Stracke@hotmail.com",
+          "phoneNumber": "291.512.5551"
+        },
+        "jobTitle": "Lead Division Agent"
+      }
+    ],
+    "schema": {
+      "$id": "https://w3id.org/traceability/schemas/Person.json",
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "$comment": "{\"term\": \"Person\", \"@id\": \"https://schema.org/Person\"}",
+      "title": "Person",
+      "description": "A person",
+      "type": "object",
+      "properties": {
+        "@context": {
+          "type": "array"
+        },
+        "type": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array"
+            }
+          ]
+        },
+        "firstName": {
+          "$comment": "{\"term\": \"firstName\", \"@id\": \"https://schema.org/givenName\"}",
+          "title": "First Name",
+          "description": "Person's first name.",
+          "type": "string"
+        },
+        "lastName": {
+          "$comment": "{\"term\": \"lastName\", \"@id\": \"https://schema.org/familyName\"}",
+          "title": "Last Name",
+          "description": "Person's last name.",
+          "type": "string"
+        },
+        "email": {
+          "$comment": "{\"term\": \"email\", \"@id\": \"https://schema.org/email\"}",
+          "title": "Person's Email Address",
+          "description": "Person's email address.",
+          "type": "string"
+        },
+        "phoneNumber": {
+          "$comment": "{\"term\": \"phoneNumber\", \"@id\": \"https://schema.org/telephone\"}",
+          "title": "Phone Number",
+          "description": "Person's contact phone number.",
+          "type": "string"
+        },
+        "worksFor": {
+          "$comment": "{\"term\": \"worksFor\", \"@id\": \"https://schema.org/worksFor\"}",
+          "title": "Works For",
+          "description": "Company which employs the person.",
+          "$ref": "https://w3id.org/traceability/schemas/Organization.json"
+        },
+        "jobTitle": {
+          "$comment": "{\"term\": \"jobTitle\", \"@id\": \"https://schema.org/jobTitle\"}",
+          "title": "Job Title",
+          "description": "Person's job title.",
+          "type": "string"
         }
       },
       "additionalProperties": false,
@@ -2015,6 +3428,338 @@
       "additionalProperties": false,
       "examples": []
     }
+  },
+  "https://schema.org/Product": {
+    "$id": "https://w3id.org/traceability/schemas/Product.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$comment": {
+      "term": "Product",
+      "@id": "https://schema.org/Product"
+    },
+    "title": "Product",
+    "description": "A product",
+    "classProperties": {
+      "https://schema.org/manufacturer": {
+        "$comment": {
+          "term": "manufacturer",
+          "@id": "https://schema.org/manufacturer"
+        },
+        "title": "Manufacturer",
+        "description": "The entity manufacturing the product."
+      },
+      "https://schema.org/name": {
+        "$comment": {
+          "term": "name",
+          "@id": "https://schema.org/name"
+        },
+        "title": "Name",
+        "description": "Name of the shipment item(s)"
+      },
+      "https://schema.org/description": {
+        "$comment": {
+          "term": "description",
+          "@id": "https://schema.org/description"
+        },
+        "title": "Description",
+        "description": "Description of the shipment."
+      },
+      "https://schema.org/size": {
+        "$comment": {
+          "term": "sizeOrAmount",
+          "@id": "https://schema.org/size"
+        },
+        "title": "Size or Amount",
+        "description": "The size or amount of the product"
+      },
+      "https://schema.org/weight": {
+        "$comment": {
+          "term": "weight",
+          "@id": "https://schema.org/weight"
+        },
+        "title": "Weight",
+        "description": "Weight of the product."
+      },
+      "https://schema.org/sku": {
+        "$comment": {
+          "term": "sku",
+          "@id": "https://schema.org/sku"
+        },
+        "title": "Sku Number",
+        "description": "The Stock Keeping Unit (SKU), i.e. a merchant-specific identifier for a product or service, or the product to which the offer refers."
+      }
+    },
+    "examples": [
+      {
+        "@context": [
+          "https://w3id.org/traceability/v1"
+        ],
+        "type": "Product",
+        "manufacturer": {
+          "type": "Person",
+          "firstName": "Jerrod",
+          "lastName": "Bogan",
+          "email": "Odessa39@gmail.com",
+          "phoneNumber": "(574) 269-8462 x579",
+          "worksFor": {
+            "type": "Organization",
+            "name": "Emmerich, Mante and Donnelly",
+            "description": "Implemented disintermediate groupware",
+            "address": {
+              "type": "PostalAddress",
+              "streetAddress": "45308 Jaycee Vista",
+              "addressLocality": "Eusebiofort",
+              "addressRegion": "South Dakota",
+              "postalCode": "30949-9264",
+              "addressCountry": "Estonia"
+            },
+            "email": "Claude_Kihn26@yahoo.com",
+            "phoneNumber": "683-380-4851"
+          },
+          "jobTitle": "Corporate Data Orchestrator"
+        },
+        "name": "Sleek Frozen Mouse",
+        "description": "The Nagasaki Lander is the trademarked name of several series of Nagasaki sport bikes, that started with the 1984 ABC800J",
+        "sizeOrAmount": {
+          "type": "QuantitativeValue",
+          "unitCode": "hg/ha",
+          "value": "5912"
+        },
+        "weight": {
+          "type": "QuantitativeValue",
+          "unitCode": "hg/ha",
+          "value": "8206"
+        },
+        "sku": "43632142035"
+      },
+      {
+        "@context": [
+          "https://w3id.org/traceability/v1"
+        ],
+        "type": "Product",
+        "manufacturer": {
+          "type": "Person",
+          "firstName": "Yazmin",
+          "lastName": "Abernathy",
+          "email": "Sven.Schmeler@yahoo.com",
+          "phoneNumber": "(488) 716-9876 x18990",
+          "worksFor": {
+            "type": "Organization",
+            "name": "Dietrich - Reichel",
+            "description": "Reduced web-enabled extranet",
+            "address": {
+              "type": "PostalAddress",
+              "streetAddress": "3646 Aurelie Point",
+              "addressLocality": "Tessieberg",
+              "addressRegion": "Oregon",
+              "postalCode": "28003-5169",
+              "addressCountry": "Sao Tome and Principe"
+            },
+            "email": "Gideon4@yahoo.com",
+            "phoneNumber": "870.993.9296"
+          },
+          "jobTitle": "National Brand Director"
+        },
+        "name": "Unbranded Plastic Hat",
+        "description": "The Apollotech B340 is an affordable wireless mouse with reliable connectivity, 12 months battery life and modern design",
+        "sizeOrAmount": {
+          "type": "QuantitativeValue",
+          "unitCode": "hg/ha",
+          "value": "3306"
+        },
+        "weight": {
+          "type": "QuantitativeValue",
+          "unitCode": "hg/ha",
+          "value": "2452"
+        },
+        "sku": "407472905958"
+      },
+      {
+        "@context": [
+          "https://w3id.org/traceability/v1"
+        ],
+        "type": "Product",
+        "manufacturer": {
+          "type": "Organization",
+          "name": "Sanford - Legros",
+          "description": "Cross-group content-based migration",
+          "address": {
+            "type": "PostalAddress",
+            "streetAddress": "291 Torp Summit",
+            "addressLocality": "Americaport",
+            "addressRegion": "Tennessee",
+            "postalCode": "23280",
+            "addressCountry": "Spain"
+          },
+          "email": "Selmer_Upton43@hotmail.com",
+          "phoneNumber": "(872) 937-5989"
+        },
+        "name": "Sleek Wooden Sausages",
+        "description": "Andy shoes are designed to keeping in mind durability as well as trends, the most stylish range of shoes & sandals",
+        "sizeOrAmount": {
+          "type": "QuantitativeValue",
+          "unitCode": "hg/ha",
+          "value": "8972"
+        },
+        "weight": {
+          "type": "QuantitativeValue",
+          "unitCode": "hg/ha",
+          "value": "3156"
+        },
+        "sku": "475876054302"
+      }
+    ],
+    "schema": {
+      "$id": "https://w3id.org/traceability/schemas/Product.json",
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "$comment": "{\"term\": \"Product\", \"@id\": \"https://schema.org/Product\"}",
+      "title": "Product",
+      "description": "A product",
+      "type": "object",
+      "properties": {
+        "@context": {
+          "type": "array"
+        },
+        "type": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array"
+            }
+          ]
+        },
+        "manufacturer": {
+          "$comment": "{\"term\": \"manufacturer\", \"@id\": \"https://schema.org/manufacturer\"}",
+          "title": "Manufacturer",
+          "description": "The entity manufacturing the product.",
+          "$ref": "https://w3id.org/traceability/schemas/Entity.json"
+        },
+        "name": {
+          "$comment": "{\"term\": \"name\", \"@id\": \"https://schema.org/name\"}",
+          "title": "Name",
+          "description": "Name of the shipment item(s)",
+          "type": "string"
+        },
+        "description": {
+          "$comment": "{\"term\": \"description\", \"@id\": \"https://schema.org/description\"}",
+          "title": "Description",
+          "description": "Description of the shipment.",
+          "type": "string"
+        },
+        "sizeOrAmount": {
+          "$comment": "{\"term\": \"sizeOrAmount\", \"@id\": \"https://schema.org/size\"}",
+          "title": "Size or Amount",
+          "description": "The size or amount of the product",
+          "$ref": "https://w3id.org/traceability/schemas/QuantitativeValue.json"
+        },
+        "weight": {
+          "$comment": "{\"term\": \"weight\", \"@id\": \"https://schema.org/weight\"}",
+          "title": "Weight",
+          "description": "Weight of the product.",
+          "$ref": "https://w3id.org/traceability/schemas/QuantitativeValue.json"
+        },
+        "sku": {
+          "$comment": "{\"term\": \"sku\", \"@id\": \"https://schema.org/sku\"}",
+          "title": "Sku Number",
+          "description": "The Stock Keeping Unit (SKU), i.e. a merchant-specific identifier for a product or service, or the product to which the offer refers.",
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "examples": []
+    }
+  },
+  "https://schema.org/QuantitativeValue": {
+    "$id": "https://w3id.org/traceability/schemas/QuantitativeValue.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$comment": {
+      "term": "QuantitativeValue",
+      "@id": "https://schema.org/QuantitativeValue"
+    },
+    "title": "Quantitative Value",
+    "description": "A point value or interval for product characteristics and other purposes",
+    "classProperties": {
+      "https://schema.org/unitCode": {
+        "$comment": {
+          "term": "unitCode",
+          "@id": "https://schema.org/unitCode"
+        },
+        "title": "Unit Code",
+        "description": "Unit of measurement."
+      },
+      "https://schema.org/value": {
+        "$comment": {
+          "term": "value",
+          "@id": "https://schema.org/value"
+        },
+        "title": "Value",
+        "description": "Value or amount."
+      }
+    },
+    "examples": [
+      {
+        "@context": [
+          "https://w3id.org/traceability/v1"
+        ],
+        "type": "QuantitativeValue",
+        "unitCode": "hg/ha",
+        "value": "7845"
+      },
+      {
+        "@context": [
+          "https://w3id.org/traceability/v1"
+        ],
+        "type": "QuantitativeValue",
+        "unitCode": "hg/ha",
+        "value": "7816"
+      },
+      {
+        "@context": [
+          "https://w3id.org/traceability/v1"
+        ],
+        "type": "QuantitativeValue",
+        "unitCode": "hg/ha",
+        "value": "6399"
+      }
+    ],
+    "schema": {
+      "$id": "https://w3id.org/traceability/schemas/QuantitativeValue.json",
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "$comment": "{\"term\": \"QuantitativeValue\", \"@id\": \"https://schema.org/QuantitativeValue\"}",
+      "title": "Quantitative Value",
+      "description": "A point value or interval for product characteristics and other purposes",
+      "type": "object",
+      "properties": {
+        "@context": {
+          "type": "array"
+        },
+        "type": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array"
+            }
+          ]
+        },
+        "unitCode": {
+          "$comment": "{\"term\": \"unitCode\", \"@id\": \"https://schema.org/unitCode\"}",
+          "title": "Unit Code",
+          "description": "Unit of measurement.",
+          "type": "string"
+        },
+        "value": {
+          "$comment": "{\"term\": \"value\", \"@id\": \"https://schema.org/value\"}",
+          "title": "Value",
+          "description": "Value or amount.",
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "examples": []
+    }
   }
 }
             </script>
@@ -2022,7 +3767,7 @@
       <p id="vocab-last-generated" class="note">
       This vocabulary was last generated
       <span id="vocab-last-generated-date">
-      Wednesday, November 25, 2020 1:05 PM
+      Tuesday, December 8, 2020 11:54 AM
       </span>
             </p>
     </section>

--- a/docs/intermediate.json
+++ b/docs/intermediate.json
@@ -9,18 +9,18 @@
     "title": "Agriculture Inspection Report",
     "description": "Information on the Inspection and the observations made",
     "classProperties": {
-      "https://schema.org/Place": {
+      "https://w3id.org/traceability/schemas/Place.json": {
         "$comment": {
           "term": "facility",
-          "@id": "https://schema.org/Place"
+          "@id": "https://w3id.org/traceability/schemas/Place.json"
         },
         "title": "Facility Identifier",
         "description": "Identifiers for an inspection facility."
       },
-      "https://w3id.org/traceability/schemas/inspector": {
+      "https://w3id.org/traceability/schemas/Inspector": {
         "$comment": {
           "term": "inspector",
-          "@id": "https://w3id.org/traceability/schemas/inspector"
+          "@id": "https://w3id.org/traceability/schemas/Inspector"
         },
         "title": "Inspector",
         "description": "Inspector performing the Aggriculture Inspection"
@@ -33,13 +33,13 @@
         "title": "Shipment",
         "description": "Details for a shipment of goods."
       },
-      "https://schema.org/identifier": {
+      "https://w3id.org/traceability/schemas/Entity": {
         "$comment": {
-          "term": "applicantId",
-          "@id": "https://schema.org/identifier"
+          "term": "applicant",
+          "@id": "https://w3id.org/traceability/schemas/Entity"
         },
-        "title": "Applicant Identifier",
-        "description": "Identifiers for the entity inspection applicant."
+        "title": "Applicant",
+        "description": "Entity that is applying for the inspection."
       },
       "https://schema.org/DateTime": {
         "$comment": {
@@ -67,7 +67,602 @@
         "description": "List of observations"
       }
     },
-    "examples": [],
+    "examples": [
+      {
+        "@context": [
+          "https://w3id.org/traceability/v1"
+        ],
+        "type": "AgInspectionReport",
+        "facility": {
+          "type": "Place",
+          "globalLocationNumber": "5094112557724",
+          "geo": {
+            "type": "GeoCoordinates",
+            "latitude": "6.9367",
+            "longitude": "70.2528"
+          },
+          "address": {
+            "type": "PostalAddress",
+            "organizationName": "Swift - Larkin",
+            "streetAddress": "1167 Nelle Wells",
+            "addressLocality": "Caroleville",
+            "addressRegion": "North Carolina",
+            "postalCode": "17085-4582",
+            "addressCountry": "Puerto Rico"
+          }
+        },
+        "inspector": {
+          "type": "Inspector",
+          "person": {
+            "type": "Person",
+            "firstName": "Sofia",
+            "lastName": "Runolfsdottir",
+            "email": "Edgardo17@hotmail.com",
+            "phoneNumber": "(874) 571-1664 x187",
+            "worksFor": {
+              "type": "Organization",
+              "name": "Conroy, Herman and Kreiger",
+              "description": "Quality-focused bifurcated moratorium",
+              "address": {
+                "type": "PostalAddress",
+                "streetAddress": "066 Rahul Squares",
+                "addressLocality": "D'Amorefurt",
+                "addressRegion": "Delaware",
+                "postalCode": "16365-8130",
+                "addressCountry": "Croatia"
+              },
+              "email": "Elinor64@gmail.com",
+              "phoneNumber": "(501) 413-3480 x274"
+            },
+            "jobTitle": "Direct Mobility Officer"
+          },
+          "credential": [
+            {
+              "type": "Credential",
+              "credentialCategory": "District Infrastructure Specialist",
+              "credentialValue": "Agent"
+            },
+            {
+              "type": "Credential",
+              "credentialCategory": "National Implementation Coordinator",
+              "credentialValue": "Technician"
+            }
+          ]
+        },
+        "shipment": {
+          "type": "ParcelDelivery",
+          "deliveryAddress": {
+            "type": "PostalAddress",
+            "organizationName": "Ortiz, Pouros and Steuber",
+            "streetAddress": "0553 Xander Parkway",
+            "addressLocality": "South Skye",
+            "addressRegion": "Connecticut",
+            "postalCode": "86326",
+            "addressCountry": "Iraq"
+          },
+          "originAddress": {
+            "type": "PostalAddress",
+            "organizationName": "Boyle, Hane and Corkery",
+            "streetAddress": "987 Cameron Valley",
+            "addressLocality": "New Electaburgh",
+            "addressRegion": "Nevada",
+            "postalCode": "48332-0620",
+            "addressCountry": "Gibraltar"
+          },
+          "trackingNumber": "503164088156",
+          "products": [
+            {
+              "type": "Product",
+              "manufacturer": {
+                "type": "Organization",
+                "name": "Heaney - Grady",
+                "description": "Reverse-engineered client-driven matrix",
+                "address": {
+                  "type": "PostalAddress",
+                  "streetAddress": "1870 Hintz Terrace",
+                  "addressLocality": "South Abbey",
+                  "addressRegion": "Iowa",
+                  "postalCode": "42210",
+                  "addressCountry": "Republic of Korea"
+                },
+                "email": "Brock.Hartmann82@yahoo.com",
+                "phoneNumber": "461-525-5187 x42208"
+              },
+              "name": "Small Plastic Bacon",
+              "description": "Carbonite web goalkeeper gloves are ergonomically designed to give easy fit",
+              "sizeOrAmount": {
+                "type": "QuantitativeValue",
+                "unitCode": "hg/ha",
+                "value": "6178"
+              },
+              "weight": {
+                "type": "QuantitativeValue",
+                "unitCode": "hg/ha",
+                "value": "5960"
+              },
+              "sku": "88259203676"
+            }
+          ]
+        },
+        "applicant": {
+          "type": "Person",
+          "firstName": "Jaylon",
+          "lastName": "Bradtke",
+          "email": "Zane_Pollich39@yahoo.com",
+          "phoneNumber": "847-262-8755",
+          "worksFor": {
+            "type": "Organization",
+            "name": "Gaylord, Brown and Kunde",
+            "description": "Persevering interactive protocol",
+            "address": {
+              "type": "PostalAddress",
+              "streetAddress": "657 Beverly Hills",
+              "addressLocality": "Rogahnfurt",
+              "addressRegion": "New Mexico",
+              "postalCode": "73208",
+              "addressCountry": "Iran"
+            },
+            "email": "Jana_Hagenes@gmail.com",
+            "phoneNumber": "1-731-783-9434 x174"
+          },
+          "jobTitle": "Central Paradigm Facilitator"
+        },
+        "inspectionDate": "11-2-2020",
+        "inspectionType": "Phytosanitary",
+        "observation": [
+          {
+            "type": "Observation",
+            "property": {
+              "type": "ChemicalProperty",
+              "name": "Ruthenium",
+              "formula": "Ru",
+              "inchi": "InChI=1S/Ru",
+              "inchikey": "KJTLSVCANCCWHF-UHFFFAOYSA-N"
+            },
+            "measurement": {
+              "value": "88.180",
+              "unitCode": "P1"
+            }
+          },
+          {
+            "type": "Observation",
+            "property": {
+              "type": "ChemicalProperty",
+              "name": "Lawrencium",
+              "formula": "Lr",
+              "inchi": "InChI=1S/Lr",
+              "inchikey": "CNQCVBJFEGMYDW-UHFFFAOYSA-N"
+            },
+            "measurement": {
+              "value": "11.820",
+              "unitCode": "P1"
+            }
+          }
+        ]
+      },
+      {
+        "@context": [
+          "https://w3id.org/traceability/v1"
+        ],
+        "type": "AgInspectionReport",
+        "facility": {
+          "type": "Place",
+          "globalLocationNumber": "5461635410698",
+          "geo": {
+            "type": "GeoCoordinates",
+            "latitude": "9.6831",
+            "longitude": "38.8686"
+          },
+          "address": {
+            "type": "PostalAddress",
+            "organizationName": "Veum - Tillman",
+            "streetAddress": "43086 Margaret Parks",
+            "addressLocality": "Ritchiemouth",
+            "addressRegion": "South Carolina",
+            "postalCode": "34553-8056",
+            "addressCountry": "Taiwan"
+          }
+        },
+        "inspector": {
+          "type": "Inspector",
+          "person": {
+            "type": "Person",
+            "firstName": "Lucio",
+            "lastName": "Bosco",
+            "email": "Nedra_Beahan@gmail.com",
+            "phoneNumber": "493.926.1850 x981",
+            "worksFor": {
+              "type": "Organization",
+              "name": "Herman, Langworth and Shanahan",
+              "description": "Integrated dedicated methodology",
+              "address": {
+                "type": "PostalAddress",
+                "streetAddress": "41419 Metz Camp",
+                "addressLocality": "Lake Althea",
+                "addressRegion": "Virginia",
+                "postalCode": "93531",
+                "addressCountry": "Gambia"
+              },
+              "email": "Melvin_Wisozk@hotmail.com",
+              "phoneNumber": "1-907-898-1822 x31897"
+            },
+            "jobTitle": "Dynamic Infrastructure Technician"
+          },
+          "credential": [
+            {
+              "type": "Credential",
+              "credentialCategory": "Forward Mobility Agent",
+              "credentialValue": "Orchestrator"
+            }
+          ]
+        },
+        "shipment": {
+          "type": "ParcelDelivery",
+          "deliveryAddress": {
+            "type": "PostalAddress",
+            "organizationName": "Williamson - Tromp",
+            "streetAddress": "399 Demetris Dam",
+            "addressLocality": "West Malloryborough",
+            "addressRegion": "Wisconsin",
+            "postalCode": "17952-8678",
+            "addressCountry": "Guatemala"
+          },
+          "originAddress": {
+            "type": "PostalAddress",
+            "organizationName": "Johns, Krajcik and Windler",
+            "streetAddress": "938 Bednar Locks",
+            "addressLocality": "East Noelshire",
+            "addressRegion": "Ohio",
+            "postalCode": "15758",
+            "addressCountry": "Denmark"
+          },
+          "trackingNumber": "551197846908",
+          "products": [
+            {
+              "type": "Product",
+              "manufacturer": {
+                "type": "Person",
+                "firstName": "Russell",
+                "lastName": "Lehner",
+                "email": "Dell20@yahoo.com",
+                "phoneNumber": "820.558.7250",
+                "worksFor": {
+                  "type": "Organization",
+                  "name": "Durgan - Brown",
+                  "description": "Devolved global monitoring",
+                  "address": {
+                    "type": "PostalAddress",
+                    "streetAddress": "8055 Gerlach Roads",
+                    "addressLocality": "Port Sibyl",
+                    "addressRegion": "Louisiana",
+                    "postalCode": "61304-3589",
+                    "addressCountry": "Azerbaijan"
+                  },
+                  "email": "Diana_Bartoletti@yahoo.com",
+                  "phoneNumber": "1-924-561-8943"
+                },
+                "jobTitle": "Dynamic Security Facilitator"
+              },
+              "name": "Tasty Steel Gloves",
+              "description": "Carbonite web goalkeeper gloves are ergonomically designed to give easy fit",
+              "sizeOrAmount": {
+                "type": "QuantitativeValue",
+                "unitCode": "hg/ha",
+                "value": "2393"
+              },
+              "weight": {
+                "type": "QuantitativeValue",
+                "unitCode": "hg/ha",
+                "value": "5415"
+              },
+              "sku": "950856140054"
+            }
+          ]
+        },
+        "applicant": {
+          "type": "Person",
+          "firstName": "Alverta",
+          "lastName": "Jacobs",
+          "email": "Brayan_Veum@yahoo.com",
+          "phoneNumber": "1-753-463-1245 x04543",
+          "worksFor": {
+            "type": "Organization",
+            "name": "Hyatt Group",
+            "description": "Customer-focused value-added interface",
+            "address": {
+              "type": "PostalAddress",
+              "streetAddress": "21199 Keely Squares",
+              "addressLocality": "Binsberg",
+              "addressRegion": "Indiana",
+              "postalCode": "85119-2230",
+              "addressCountry": "Saint Barthelemy"
+            },
+            "email": "Chadrick.Carter@yahoo.com",
+            "phoneNumber": "1-947-251-7218"
+          },
+          "jobTitle": "National Tactics Technician"
+        },
+        "inspectionDate": "11-2-2020",
+        "inspectionType": "Phytosanitary",
+        "observation": [
+          {
+            "type": "Observation",
+            "property": {
+              "type": "ChemicalProperty",
+              "name": "Iodine",
+              "formula": "I",
+              "inchi": "InChI=1S/I",
+              "inchikey": "ZCYVEMRRCGMTRW-UHFFFAOYSA-N"
+            },
+            "measurement": {
+              "value": "35.694",
+              "unitCode": "P1"
+            }
+          },
+          {
+            "type": "Observation",
+            "property": {
+              "type": "ChemicalProperty",
+              "name": "Strontium",
+              "formula": "Sr",
+              "inchi": "InChI=1S/Sr",
+              "inchikey": "CIOAGBVUUVVLOB-UHFFFAOYSA-N"
+            },
+            "measurement": {
+              "value": "42.049",
+              "unitCode": "P1"
+            }
+          },
+          {
+            "type": "Observation",
+            "property": {
+              "type": "ChemicalProperty",
+              "name": "Helium",
+              "formula": "He",
+              "inchi": "InChI=1S/He",
+              "inchikey": "SWQJXJOGLNCZEY-UHFFFAOYSA-N"
+            },
+            "measurement": {
+              "value": "1.1345",
+              "unitCode": "P1"
+            }
+          },
+          {
+            "type": "Observation",
+            "property": {
+              "type": "ChemicalProperty",
+              "name": "Platinum",
+              "formula": "Pt",
+              "inchi": "InChI=1S/Pt",
+              "inchikey": "BASFCYQUMIYNBI-UHFFFAOYSA-N"
+            },
+            "measurement": {
+              "value": "21.122",
+              "unitCode": "P1"
+            }
+          }
+        ]
+      },
+      {
+        "@context": [
+          "https://w3id.org/traceability/v1"
+        ],
+        "type": "AgInspectionReport",
+        "facility": {
+          "type": "Place",
+          "globalLocationNumber": "4013194867881",
+          "geo": {
+            "type": "GeoCoordinates",
+            "latitude": "-25.5339",
+            "longitude": "-153.9454"
+          },
+          "address": {
+            "type": "PostalAddress",
+            "organizationName": "Bashirian - Bode",
+            "streetAddress": "6204 Abe Port",
+            "addressLocality": "Gorczanyside",
+            "addressRegion": "California",
+            "postalCode": "24005",
+            "addressCountry": "Kenya"
+          }
+        },
+        "inspector": {
+          "type": "Inspector",
+          "person": {
+            "type": "Person",
+            "firstName": "Michele",
+            "lastName": "Rosenbaum",
+            "email": "Addie76@hotmail.com",
+            "phoneNumber": "334-491-6248 x09191",
+            "worksFor": {
+              "type": "Organization",
+              "name": "Smith, Stroman and Kuhlman",
+              "description": "Profit-focused interactive neural-net",
+              "address": {
+                "type": "PostalAddress",
+                "streetAddress": "779 Gottlieb Port",
+                "addressLocality": "New Hilariotown",
+                "addressRegion": "Florida",
+                "postalCode": "13297-1232",
+                "addressCountry": "Hong Kong"
+              },
+              "email": "Katelyn_Gleichner@yahoo.com",
+              "phoneNumber": "(826) 938-4901"
+            },
+            "jobTitle": "Human Factors Officer"
+          },
+          "credential": [
+            {
+              "type": "Credential",
+              "credentialCategory": "Central Integration Director",
+              "credentialValue": "Officer"
+            },
+            {
+              "type": "Credential",
+              "credentialCategory": "Dynamic Data Architect",
+              "credentialValue": "Representative"
+            }
+          ]
+        },
+        "shipment": {
+          "type": "ParcelDelivery",
+          "deliveryAddress": {
+            "type": "PostalAddress",
+            "organizationName": "Bogisich - Gibson",
+            "streetAddress": "6276 Huels Parkways",
+            "addressLocality": "East Harmony",
+            "addressRegion": "South Dakota",
+            "postalCode": "12101",
+            "addressCountry": "Antarctica (the territory South of 60 deg S)"
+          },
+          "originAddress": {
+            "type": "PostalAddress",
+            "organizationName": "Mayer and Sons",
+            "streetAddress": "027 Hermiston Groves",
+            "addressLocality": "Nikolausborough",
+            "addressRegion": "Rhode Island",
+            "postalCode": "55608",
+            "addressCountry": "Ecuador"
+          },
+          "trackingNumber": "377822965748",
+          "products": [
+            {
+              "type": "Product",
+              "manufacturer": {
+                "type": "Organization",
+                "name": "Carroll and Sons",
+                "description": "Reduced stable hub",
+                "address": {
+                  "type": "PostalAddress",
+                  "streetAddress": "5515 Dibbert Fall",
+                  "addressLocality": "West Myrtie",
+                  "addressRegion": "Alaska",
+                  "postalCode": "74404-9344",
+                  "addressCountry": "Netherlands"
+                },
+                "email": "Willow.Labadie46@gmail.com",
+                "phoneNumber": "1-378-469-2484 x931"
+              },
+              "name": "Gorgeous Concrete Shirt",
+              "description": "Ergonomic executive chair upholstered in bonded black leather and PVC padded seat and back for all-day comfort and support",
+              "sizeOrAmount": {
+                "type": "QuantitativeValue",
+                "unitCode": "hg/ha",
+                "value": "9030"
+              },
+              "weight": {
+                "type": "QuantitativeValue",
+                "unitCode": "hg/ha",
+                "value": "5692"
+              },
+              "sku": "738393217334"
+            },
+            {
+              "type": "Product",
+              "manufacturer": {
+                "type": "Organization",
+                "name": "Turner, Kihn and Crona",
+                "description": "Public-key full-range open architecture",
+                "address": {
+                  "type": "PostalAddress",
+                  "streetAddress": "412 Elsa Plain",
+                  "addressLocality": "Schillerside",
+                  "addressRegion": "Kansas",
+                  "postalCode": "07159",
+                  "addressCountry": "Nigeria"
+                },
+                "email": "Anabelle.Rohan43@hotmail.com",
+                "phoneNumber": "1-456-889-9848"
+              },
+              "name": "Gorgeous Rubber Table",
+              "description": "The beautiful range of Apple Naturalé that has an exciting mix of natural ingredients. With the Goodness of 100% Natural Ingredients",
+              "sizeOrAmount": {
+                "type": "QuantitativeValue",
+                "unitCode": "hg/ha",
+                "value": "8920"
+              },
+              "weight": {
+                "type": "QuantitativeValue",
+                "unitCode": "hg/ha",
+                "value": "6527"
+              },
+              "sku": "819915551842"
+            },
+            {
+              "type": "Product",
+              "manufacturer": {
+                "type": "Person",
+                "firstName": "Demarco",
+                "lastName": "Turcotte",
+                "email": "Pietro_McCullough@gmail.com",
+                "phoneNumber": "1-492-931-1296",
+                "worksFor": {
+                  "type": "Organization",
+                  "name": "Mertz, Labadie and Lindgren",
+                  "description": "Face to face composite structure",
+                  "address": {
+                    "type": "PostalAddress",
+                    "streetAddress": "052 Chaz Fort",
+                    "addressLocality": "Hellerton",
+                    "addressRegion": "Pennsylvania",
+                    "postalCode": "44591",
+                    "addressCountry": "Sierra Leone"
+                  },
+                  "email": "Asia99@gmail.com",
+                  "phoneNumber": "401-762-5146"
+                },
+                "jobTitle": "Customer Functionality Orchestrator"
+              },
+              "name": "Handmade Rubber Pizza",
+              "description": "Andy shoes are designed to keeping in mind durability as well as trends, the most stylish range of shoes & sandals",
+              "sizeOrAmount": {
+                "type": "QuantitativeValue",
+                "unitCode": "hg/ha",
+                "value": "2979"
+              },
+              "weight": {
+                "type": "QuantitativeValue",
+                "unitCode": "hg/ha",
+                "value": "8985"
+              },
+              "sku": "234438850760"
+            }
+          ]
+        },
+        "applicant": {
+          "type": "Organization",
+          "name": "Botsford and Sons",
+          "description": "Configurable empowering flexibility",
+          "address": {
+            "type": "PostalAddress",
+            "streetAddress": "222 Cruickshank Ville",
+            "addressLocality": "West Marielle",
+            "addressRegion": "Michigan",
+            "postalCode": "45148",
+            "addressCountry": "Guadeloupe"
+          },
+          "email": "Shanon.Marvin51@hotmail.com",
+          "phoneNumber": "1-282-246-1499 x7539"
+        },
+        "inspectionDate": "11-1-2020",
+        "inspectionType": "General",
+        "observation": [
+          {
+            "type": "Observation",
+            "property": {
+              "type": "MechanicalProperty",
+              "identifier": "ISO 180",
+              "name": "Izod Impact Strength Test",
+              "description": "ISO 180 defines the method used for pendulums to determine the impact resistance of a plastic specimen when supported in a cantilever configuration. Test results are used to evaluate the resilience of materials, typically plastics."
+            },
+            "measurement": {
+              "value": "81.647",
+              "unitCode": "B13"
+            }
+          }
+        ]
+      }
+    ],
     "schema": {
       "$id": "https://w3id.org/traceability/schemas/AgInspectionReport.json",
       "$schema": "http://json-schema.org/draft-07/schema#",
@@ -90,13 +685,13 @@
           ]
         },
         "facility": {
-          "$comment": "{\"term\": \"facility\", \"@id\": \"https://schema.org/Place\"}",
+          "$comment": "{\"term\": \"facility\", \"@id\": \"https://w3id.org/traceability/schemas/Place.json\"}",
           "title": "Facility Identifier",
           "description": "Identifiers for an inspection facility.",
           "$ref": "https://w3id.org/traceability/schemas/Place.json"
         },
         "inspector": {
-          "$comment": "{\"term\": \"inspector\", \"@id\": \"https://w3id.org/traceability/schemas/inspector\"}",
+          "$comment": "{\"term\": \"inspector\", \"@id\": \"https://w3id.org/traceability/schemas/Inspector\"}",
           "title": "Inspector",
           "description": "Inspector performing the Aggriculture Inspection",
           "$ref": "https://w3id.org/traceability/schemas/Inspector.json"
@@ -105,13 +700,13 @@
           "$comment": "{\"term\": \"shipment\", \"@id\": \"https://schema.org/ParcelDelivery\"}",
           "title": "Shipment",
           "description": "Details for a shipment of goods.",
-          "$ref": "https://schema.org/version/latest/schemaorg-current-http.jsonld#https://schema.org/ParcelDelivery"
+          "$ref": "https://w3id.org/traceability/schemas/ParcelDelivery.json"
         },
-        "applicantId": {
-          "$comment": "{\"term\": \"applicantId\", \"@id\": \"https://schema.org/identifier\"}",
-          "title": "Applicant Identifier",
-          "description": "Identifiers for the entity inspection applicant.",
-          "type": "string"
+        "applicant": {
+          "$comment": "{\"term\": \"applicant\", \"@id\": \"https://w3id.org/traceability/schemas/Entity\"}",
+          "title": "Applicant",
+          "description": "Entity that is applying for the inspection.",
+          "$ref": "https://w3id.org/traceability/schemas/Entity.json"
         },
         "inspectionDate": {
           "$comment": "{\"term\": \"inspectionDate\", \"@id\": \"https://schema.org/DateTime\"}",
@@ -325,24 +920,24 @@
           "https://w3id.org/traceability/v1"
         ],
         "type": "Credential",
-        "credentialCategory": "Forward Quality Officer",
-        "credentialValue": "Engineer"
+        "credentialCategory": "Senior Creative Facilitator",
+        "credentialValue": "Manager"
       },
       {
         "@context": [
           "https://w3id.org/traceability/v1"
         ],
         "type": "Credential",
-        "credentialCategory": "International Response Specialist",
-        "credentialValue": "Architect"
+        "credentialCategory": "Senior Functionality Manager",
+        "credentialValue": "Strategist"
       },
       {
         "@context": [
           "https://w3id.org/traceability/v1"
         ],
         "type": "Credential",
-        "credentialCategory": "Principal Infrastructure Technician",
-        "credentialValue": "Specialist"
+        "credentialCategory": "Customer Optimization Producer",
+        "credentialValue": "Administrator"
       }
     ],
     "schema": {
@@ -380,6 +975,89 @@
         }
       },
       "additionalProperties": false,
+      "examples": []
+    }
+  },
+  "https://w3id.org/traceability/Entity": {
+    "$id": "https://w3id.org/traceability/schemas/Entity.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$comment": {
+      "term": "Entity",
+      "@id": "https://w3id.org/traceability/Entity"
+    },
+    "title": "Entity",
+    "description": "A person or organization.",
+    "classProperties": {},
+    "examples": [
+      {
+        "@context": [
+          "https://w3id.org/traceability/v1"
+        ],
+        "type": "Organization",
+        "name": "Buckridge Group",
+        "description": "Enhanced human-resource benchmark",
+        "address": {
+          "type": "PostalAddress",
+          "streetAddress": "2711 Nikki Keys",
+          "addressLocality": "South Ryannville",
+          "addressRegion": "Alaska",
+          "postalCode": "85791",
+          "addressCountry": "Poland"
+        },
+        "email": "Raymundo_Hodkiewicz@yahoo.com",
+        "phoneNumber": "228-474-2165 x665"
+      },
+      {
+        "@context": [
+          "https://w3id.org/traceability/v1"
+        ],
+        "type": "Organization",
+        "name": "Orn Group",
+        "description": "Phased coherent pricing structure",
+        "address": {
+          "type": "PostalAddress",
+          "streetAddress": "616 Marques Mill",
+          "addressLocality": "Lemkeshire",
+          "addressRegion": "Oregon",
+          "postalCode": "10226-9002",
+          "addressCountry": "Nigeria"
+        },
+        "email": "Kyler_Kris@hotmail.com",
+        "phoneNumber": "1-763-272-9022 x4456"
+      },
+      {
+        "@context": [
+          "https://w3id.org/traceability/v1"
+        ],
+        "type": "Organization",
+        "name": "Ernser, Lang and Herzog",
+        "description": "Synchronised intermediate interface",
+        "address": {
+          "type": "PostalAddress",
+          "streetAddress": "65406 O'Connell Light",
+          "addressLocality": "Kiehnberg",
+          "addressRegion": "Indiana",
+          "postalCode": "66751-4608",
+          "addressCountry": "Eritrea"
+        },
+        "email": "Wilton.Grady46@yahoo.com",
+        "phoneNumber": "1-878-785-3627"
+      }
+    ],
+    "schema": {
+      "$id": "https://w3id.org/traceability/schemas/Entity.json",
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "$comment": "{\"term\": \"Entity\", \"@id\": \"https://w3id.org/traceability/Entity\"}",
+      "title": "Entity",
+      "description": "A person or organization.",
+      "anyOf": [
+        {
+          "$ref": "https://w3id.org/traceability/schemas/Person.json"
+        },
+        {
+          "$ref": "https://w3id.org/traceability/schemas/Organization.json"
+        }
+      ],
       "examples": []
     }
   },
@@ -509,19 +1187,6 @@
             "type": "Observation",
             "property": {
               "type": "MechanicalProperty",
-              "identifier": "ISO 148",
-              "name": "Charpy Impact Strength Test",
-              "description": "ISO 148-1:2016 specifies the Charpy (V-notch and U-notch) pendulum impact test method for determining the energy absorbed in an impact test of metallic materials. This part of ISO 148 does not cover instrumented impact testing, which is specified in ISO 14556."
-            },
-            "measurement": {
-              "value": "24.720",
-              "unitCode": "B13"
-            }
-          },
-          {
-            "type": "Observation",
-            "property": {
-              "type": "MechanicalProperty",
               "identifier": "ISO 3738",
               "name": "Rockwell Hardness Test (Scale A)",
               "description": "The Rockwell hardness test is an empirical indentation hardness test that can provide useful information about metallic materials."
@@ -529,196 +1194,6 @@
             "measurement": {
               "value": "00.00",
               "unitCode": "UNKNOWN"
-            }
-          },
-          {
-            "type": "Observation",
-            "property": {
-              "type": "ChemicalProperty",
-              "name": "Nihonium",
-              "formula": "Nh"
-            },
-            "measurement": {
-              "value": "00.00",
-              "unitCode": "UNKNOWN"
-            }
-          },
-          {
-            "type": "Observation",
-            "property": {
-              "type": "MechanicalProperty",
-              "identifier": "ISO 148",
-              "name": "Charpy Impact Strength Test",
-              "description": "ISO 148-1:2016 specifies the Charpy (V-notch and U-notch) pendulum impact test method for determining the energy absorbed in an impact test of metallic materials. This part of ISO 148 does not cover instrumented impact testing, which is specified in ISO 14556."
-            },
-            "measurement": {
-              "value": "66.711",
-              "unitCode": "B13"
-            }
-          },
-          {
-            "type": "Observation",
-            "property": {
-              "type": "ChemicalProperty",
-              "name": "Thulium",
-              "formula": "Tm",
-              "inchi": "InChI=1S/Tm",
-              "inchikey": "FRNOGLGSGLTDKL-UHFFFAOYSA-N"
-            },
-            "measurement": {
-              "value": "31.503",
-              "unitCode": "P1"
-            }
-          },
-          {
-            "type": "Observation",
-            "property": {
-              "type": "MechanicalProperty",
-              "identifier": "ISO 3738",
-              "name": "Rockwell Hardness Test (Scale A)",
-              "description": "The Rockwell hardness test is an empirical indentation hardness test that can provide useful information about metallic materials."
-            },
-            "measurement": {
-              "value": "00.00",
-              "unitCode": "UNKNOWN"
-            }
-          },
-          {
-            "type": "Observation",
-            "property": {
-              "type": "MechanicalProperty",
-              "identifier": "ISO 1352",
-              "name": "Torque-controlled fatigue testing",
-              "description": "ISO 1352:2011 specifies the conditions for performing torsional, constant-amplitude, nominally elastic stress fatigue tests on metallic specimens without deliberately introducing stress concentrations. The tests are carried out at ambient temperature (ideally at between 10 °C and 35 °C) in air by applying a pure couple to the specimen about its longitudinal axis."
-            },
-            "measurement": {
-              "value": "00.00",
-              "unitCode": "UNKNOWN"
-            }
-          },
-          {
-            "type": "Observation",
-            "property": {
-              "type": "MechanicalProperty",
-              "identifier": "ISO 3738",
-              "name": "Rockwell Hardness Test (Scale A)",
-              "description": "The Rockwell hardness test is an empirical indentation hardness test that can provide useful information about metallic materials."
-            },
-            "measurement": {
-              "value": "00.00",
-              "unitCode": "UNKNOWN"
-            }
-          },
-          {
-            "type": "Observation",
-            "property": {
-              "type": "ChemicalProperty",
-              "name": "Boron",
-              "formula": "B",
-              "inchi": "InChI=1S/B",
-              "inchikey": "ZOXJGFHDIHLPTG-UHFFFAOYSA-N"
-            },
-            "measurement": {
-              "value": "68.497",
-              "unitCode": "P1"
-            }
-          }
-        ]
-      },
-      {
-        "@context": [
-          "https://w3id.org/traceability/v1"
-        ],
-        "type": "InspectionReport",
-        "observation": [
-          {
-            "type": "Observation",
-            "property": {
-              "type": "ChemicalProperty",
-              "name": "Cesium",
-              "formula": "Cs",
-              "inchi": "InChI=1S/Cs",
-              "inchikey": "TVFDJXOCXUVLDH-UHFFFAOYSA-N"
-            },
-            "measurement": {
-              "value": "32.812",
-              "unitCode": "P1"
-            }
-          },
-          {
-            "type": "Observation",
-            "property": {
-              "type": "ChemicalProperty",
-              "name": "Antimony",
-              "formula": "Sb",
-              "inchi": "InChI=1S/Sb",
-              "inchikey": "WATWJIUSRGPENY-UHFFFAOYSA-N"
-            },
-            "measurement": {
-              "value": "40.179",
-              "unitCode": "P1"
-            }
-          },
-          {
-            "type": "Observation",
-            "property": {
-              "type": "ChemicalProperty",
-              "name": "Selenium",
-              "formula": "Se",
-              "inchi": "InChI=1S/Se",
-              "inchikey": "BUGBHKTXTAQXES-UHFFFAOYSA-N"
-            },
-            "measurement": {
-              "value": "3.3154",
-              "unitCode": "P1"
-            }
-          },
-          {
-            "type": "Observation",
-            "property": {
-              "type": "ChemicalProperty",
-              "name": "Nihonium",
-              "formula": "Nh"
-            },
-            "measurement": {
-              "value": "00.00",
-              "unitCode": "UNKNOWN"
-            }
-          },
-          {
-            "type": "Observation",
-            "property": {
-              "type": "ChemicalProperty",
-              "name": "Scandium",
-              "formula": "Sc",
-              "inchi": "InChI=1S/Sc",
-              "inchikey": "SIXSYDAISGFNSX-UHFFFAOYSA-N"
-            },
-            "measurement": {
-              "value": "23.694",
-              "unitCode": "P1"
-            }
-          }
-        ]
-      },
-      {
-        "@context": [
-          "https://w3id.org/traceability/v1"
-        ],
-        "type": "InspectionReport",
-        "observation": [
-          {
-            "type": "Observation",
-            "property": {
-              "type": "ChemicalProperty",
-              "name": "Indium",
-              "formula": "In",
-              "inchi": "InChI=1S/In",
-              "inchikey": "APFVFJFRJDLVQX-UHFFFAOYSA-N"
-            },
-            "measurement": {
-              "value": "33.267",
-              "unitCode": "P1"
             }
           },
           {
@@ -731,7 +1206,7 @@
               "inchikey": "KLMCZVJOEAUDNE-UHFFFAOYSA-N"
             },
             "measurement": {
-              "value": "28.949",
+              "value": "100.00",
               "unitCode": "P1"
             }
           },
@@ -739,14 +1214,12 @@
             "type": "Observation",
             "property": {
               "type": "ChemicalProperty",
-              "name": "Krypton",
-              "formula": "Kr",
-              "inchi": "InChI=1S/Kr",
-              "inchikey": "DNNSSWSSYDEUBZ-UHFFFAOYSA-N"
+              "name": "Seaborgium",
+              "formula": "Sg"
             },
             "measurement": {
-              "value": "37.783",
-              "unitCode": "P1"
+              "value": "00.00",
+              "unitCode": "UNKNOWN"
             }
           },
           {
@@ -758,7 +1231,28 @@
               "description": "ISO 180 defines the method used for pendulums to determine the impact resistance of a plastic specimen when supported in a cantilever configuration. Test results are used to evaluate the resilience of materials, typically plastics."
             },
             "measurement": {
-              "value": "92.316",
+              "value": "50.487",
+              "unitCode": "B13"
+            }
+          }
+        ]
+      },
+      {
+        "@context": [
+          "https://w3id.org/traceability/v1"
+        ],
+        "type": "InspectionReport",
+        "observation": [
+          {
+            "type": "Observation",
+            "property": {
+              "type": "MechanicalProperty",
+              "identifier": "ISO 180",
+              "name": "Izod Impact Strength Test",
+              "description": "ISO 180 defines the method used for pendulums to determine the impact resistance of a plastic specimen when supported in a cantilever configuration. Test results are used to evaluate the resilience of materials, typically plastics."
+            },
+            "measurement": {
+              "value": "62.515",
               "unitCode": "B13"
             }
           },
@@ -766,13 +1260,63 @@
             "type": "Observation",
             "property": {
               "type": "MechanicalProperty",
-              "identifier": "ISO 1352",
-              "name": "Torque-controlled fatigue testing",
-              "description": "ISO 1352:2011 specifies the conditions for performing torsional, constant-amplitude, nominally elastic stress fatigue tests on metallic specimens without deliberately introducing stress concentrations. The tests are carried out at ambient temperature (ideally at between 10 °C and 35 °C) in air by applying a pure couple to the specimen about its longitudinal axis."
+              "identifier": "ISO 148",
+              "name": "Charpy Impact Strength Test",
+              "description": "ISO 148-1:2016 specifies the Charpy (V-notch and U-notch) pendulum impact test method for determining the energy absorbed in an impact test of metallic materials. This part of ISO 148 does not cover instrumented impact testing, which is specified in ISO 14556."
             },
             "measurement": {
-              "value": "00.00",
-              "unitCode": "UNKNOWN"
+              "value": "96.659",
+              "unitCode": "B13"
+            }
+          },
+          {
+            "type": "Observation",
+            "property": {
+              "type": "ChemicalProperty",
+              "name": "Cobalt",
+              "formula": "Co",
+              "inchi": "InChI=1S/Co",
+              "inchikey": "GUTLYIVDDKVIGB-UHFFFAOYSA-N"
+            },
+            "measurement": {
+              "value": "100.00",
+              "unitCode": "P1"
+            }
+          }
+        ]
+      },
+      {
+        "@context": [
+          "https://w3id.org/traceability/v1"
+        ],
+        "type": "InspectionReport",
+        "observation": [
+          {
+            "type": "Observation",
+            "property": {
+              "type": "ChemicalProperty",
+              "name": "Xenon",
+              "formula": "Xe",
+              "inchi": "InChI=1S/Xe",
+              "inchikey": "FHNFHKCVQCLJFQ-UHFFFAOYSA-N"
+            },
+            "measurement": {
+              "value": "15.885",
+              "unitCode": "P1"
+            }
+          },
+          {
+            "type": "Observation",
+            "property": {
+              "type": "ChemicalProperty",
+              "name": "Gold",
+              "formula": "Au",
+              "inchi": "InChI=1S/Au",
+              "inchikey": "PCHJSUWPFVWCPO-UHFFFAOYSA-N"
+            },
+            "measurement": {
+              "value": "3.1246",
+              "unitCode": "P1"
             }
           },
           {
@@ -791,14 +1335,69 @@
           {
             "type": "Observation",
             "property": {
-              "type": "MechanicalProperty",
-              "identifier": "ISO 180",
-              "name": "Izod Impact Strength Test",
-              "description": "ISO 180 defines the method used for pendulums to determine the impact resistance of a plastic specimen when supported in a cantilever configuration. Test results are used to evaluate the resilience of materials, typically plastics."
+              "type": "ChemicalProperty",
+              "name": "Sodium",
+              "formula": "Na",
+              "inchi": "InChI=1S/Na",
+              "inchikey": "KEAYESYHFKHZAL-UHFFFAOYSA-N"
             },
             "measurement": {
-              "value": "78.265",
-              "unitCode": "B13"
+              "value": "28.043",
+              "unitCode": "P1"
+            }
+          },
+          {
+            "type": "Observation",
+            "property": {
+              "type": "MechanicalProperty",
+              "identifier": "ISO 3738",
+              "name": "Rockwell Hardness Test (Scale A)",
+              "description": "The Rockwell hardness test is an empirical indentation hardness test that can provide useful information about metallic materials."
+            },
+            "measurement": {
+              "value": "00.00",
+              "unitCode": "UNKNOWN"
+            }
+          },
+          {
+            "type": "Observation",
+            "property": {
+              "type": "ChemicalProperty",
+              "name": "Aluminium",
+              "formula": "Al",
+              "inchi": "InChI=1S/Al",
+              "inchikey": "XAGFODPZIPBFFR-UHFFFAOYSA-N"
+            },
+            "measurement": {
+              "value": "39.861",
+              "unitCode": "P1"
+            }
+          },
+          {
+            "type": "Observation",
+            "property": {
+              "type": "ChemicalProperty",
+              "name": "Radon",
+              "formula": "Rn",
+              "inchi": "InChI=1S/Rn",
+              "inchikey": "SYUHGPGVQRZVTB-UHFFFAOYSA-N"
+            },
+            "measurement": {
+              "value": "13.087",
+              "unitCode": "P1"
+            }
+          },
+          {
+            "type": "Observation",
+            "property": {
+              "type": "MechanicalProperty",
+              "identifier": "ISO 1352",
+              "name": "Torque-controlled fatigue testing",
+              "description": "ISO 1352:2011 specifies the conditions for performing torsional, constant-amplitude, nominally elastic stress fatigue tests on metallic specimens without deliberately introducing stress concentrations. The tests are carried out at ambient temperature (ideally at between 10 °C and 35 °C) in air by applying a pure couple to the specimen about its longitudinal axis."
+            },
+            "measurement": {
+              "value": "00.00",
+              "unitCode": "UNKNOWN"
             }
           }
         ]
@@ -849,10 +1448,10 @@
     "title": "Inspector",
     "description": "Information on the person performing an inspection",
     "classProperties": {
-      "https://schema.org/Person": {
+      "https://w3id.org/traceability/schemas/Person.json": {
         "$comment": {
           "term": "person",
-          "@id": "https://schema.org/Person"
+          "@id": "https://w3id.org/traceability/schemas/Person.json"
         },
         "title": "Person",
         "description": "Person doing the inspection."
@@ -873,17 +1472,34 @@
           "https://w3id.org/traceability/v1"
         ],
         "type": "Inspector",
-        "person": "Julius Hartmann",
+        "person": {
+          "type": "Person",
+          "firstName": "Evie",
+          "lastName": "Kuhic",
+          "email": "Minnie29@yahoo.com",
+          "phoneNumber": "(377) 777-0267 x195",
+          "worksFor": {
+            "type": "Organization",
+            "name": "Hane - Lang",
+            "description": "Programmable directional software",
+            "address": {
+              "type": "PostalAddress",
+              "streetAddress": "9567 Wunsch Square",
+              "addressLocality": "North Jade",
+              "addressRegion": "Alaska",
+              "postalCode": "74640",
+              "addressCountry": "Grenada"
+            },
+            "email": "Koby58@gmail.com",
+            "phoneNumber": "377-887-6127 x3853"
+          },
+          "jobTitle": "Dynamic Response Technician"
+        },
         "credential": [
           {
             "type": "Credential",
-            "credentialCategory": "Corporate Research Designer",
-            "credentialValue": "Architect"
-          },
-          {
-            "type": "Credential",
-            "credentialCategory": "International Security Producer",
-            "credentialValue": "Producer"
+            "credentialCategory": "Global Identity Administrator",
+            "credentialValue": "Agent"
           }
         ]
       },
@@ -892,22 +1508,34 @@
           "https://w3id.org/traceability/v1"
         ],
         "type": "Inspector",
-        "person": "Sheryl Heidenreich",
+        "person": {
+          "type": "Person",
+          "firstName": "Horace",
+          "lastName": "Bashirian",
+          "email": "Carlee89@gmail.com",
+          "phoneNumber": "227.753.9606 x7274",
+          "worksFor": {
+            "type": "Organization",
+            "name": "Casper - Hintz",
+            "description": "Grass-roots next generation info-mediaries",
+            "address": {
+              "type": "PostalAddress",
+              "streetAddress": "51258 Kub Courts",
+              "addressLocality": "Port Lilianabury",
+              "addressRegion": "Wyoming",
+              "postalCode": "38565",
+              "addressCountry": "Namibia"
+            },
+            "email": "Gaylord26@yahoo.com",
+            "phoneNumber": "911-751-7313"
+          },
+          "jobTitle": "Corporate Quality Designer"
+        },
         "credential": [
           {
             "type": "Credential",
-            "credentialCategory": "Direct Group Analyst",
-            "credentialValue": "Liaison"
-          },
-          {
-            "type": "Credential",
-            "credentialCategory": "Chief Communications Coordinator",
-            "credentialValue": "Strategist"
-          },
-          {
-            "type": "Credential",
-            "credentialCategory": "Corporate Paradigm Assistant",
-            "credentialValue": "Planner"
+            "credentialCategory": "Legacy Mobility Designer",
+            "credentialValue": "Coordinator"
           }
         ]
       },
@@ -916,17 +1544,44 @@
           "https://w3id.org/traceability/v1"
         ],
         "type": "Inspector",
-        "person": "Erin Considine III",
+        "person": {
+          "type": "Person",
+          "firstName": "Hester",
+          "lastName": "Bahringer",
+          "email": "Bria_Mante1@gmail.com",
+          "phoneNumber": "(593) 911-0654 x485",
+          "worksFor": {
+            "type": "Organization",
+            "name": "Hamill LLC",
+            "description": "Persevering content-based implementation",
+            "address": {
+              "type": "PostalAddress",
+              "streetAddress": "601 Hirthe Circles",
+              "addressLocality": "Friesenport",
+              "addressRegion": "Montana",
+              "postalCode": "10655-8812",
+              "addressCountry": "Paraguay"
+            },
+            "email": "Loma_Carroll85@yahoo.com",
+            "phoneNumber": "593-975-7547 x26115"
+          },
+          "jobTitle": "Chief Identity Assistant"
+        },
         "credential": [
           {
             "type": "Credential",
-            "credentialCategory": "Dynamic Functionality Manager",
-            "credentialValue": "Strategist"
+            "credentialCategory": "Human Optimization Officer",
+            "credentialValue": "Assistant"
           },
           {
             "type": "Credential",
-            "credentialCategory": "Corporate Research Producer",
-            "credentialValue": "Analyst"
+            "credentialCategory": "Regional Functionality Agent",
+            "credentialValue": "Executive"
+          },
+          {
+            "type": "Credential",
+            "credentialCategory": "District Group Administrator",
+            "credentialValue": "Coordinator"
           }
         ]
       }
@@ -953,10 +1608,10 @@
           ]
         },
         "person": {
-          "$comment": "{\"term\": \"person\", \"@id\": \"https://schema.org/Person\"}",
+          "$comment": "{\"term\": \"person\", \"@id\": \"https://w3id.org/traceability/schemas/Person.json\"}",
           "title": "Person",
           "description": "Person doing the inspection.",
-          "type": "string"
+          "$ref": "https://w3id.org/traceability/schemas/Person.json"
         },
         "credential": {
           "$comment": "{\"term\": \"credential\", \"@id\": \"https://schema.org/ItemList\", \"@type\": \"https://schema.org/ItemList\"}",
@@ -1261,14 +1916,30 @@
         ],
         "type": "Observation",
         "property": {
-          "type": "ChemicalProperty",
-          "name": "Titanium",
-          "formula": "Ti",
-          "inchi": "InChI=1S/Ti",
-          "inchikey": "RTAQQCXQSZGOHL-UHFFFAOYSA-N"
+          "type": "MechanicalProperty",
+          "identifier": "ISO 180",
+          "name": "Izod Impact Strength Test",
+          "description": "ISO 180 defines the method used for pendulums to determine the impact resistance of a plastic specimen when supported in a cantilever configuration. Test results are used to evaluate the resilience of materials, typically plastics."
         },
         "measurement": {
-          "value": "36.424",
+          "value": "39.819",
+          "unitCode": "B13"
+        }
+      },
+      {
+        "@context": [
+          "https://w3id.org/traceability/v1"
+        ],
+        "type": "Observation",
+        "property": {
+          "type": "ChemicalProperty",
+          "name": "Copper",
+          "formula": "Cu",
+          "inchi": "InChI=1S/Cu",
+          "inchikey": "RYGMFSIKBFXOCR-UHFFFAOYSA-N"
+        },
+        "measurement": {
+          "value": "86.107",
           "unitCode": "P1"
         }
       },
@@ -1279,30 +1950,13 @@
         "type": "Observation",
         "property": {
           "type": "ChemicalProperty",
-          "name": "Cadmium",
-          "formula": "Cd",
-          "inchi": "InChI=1S/Cd",
-          "inchikey": "BDOSMKKIYDKNTQ-UHFFFAOYSA-N"
+          "name": "Chromium",
+          "formula": "Cr",
+          "inchi": "InChI=1S/Cr",
+          "inchikey": "VYZAMTAEIAYCRO-UHFFFAOYSA-N"
         },
         "measurement": {
-          "value": "8.747",
-          "unitCode": "P1"
-        }
-      },
-      {
-        "@context": [
-          "https://w3id.org/traceability/v1"
-        ],
-        "type": "Observation",
-        "property": {
-          "type": "ChemicalProperty",
-          "name": "Lanthanum",
-          "formula": "La",
-          "inchi": "InChI=1S/La",
-          "inchikey": "FZLIPJUXYLNCLC-UHFFFAOYSA-N"
-        },
-        "measurement": {
-          "value": "67.285",
+          "value": "83.190",
           "unitCode": "P1"
         }
       }
@@ -1339,6 +1993,765 @@
           "title": "Measured Value",
           "description": "The measurement of an Observation.",
           "$ref": "https://w3id.org/traceability/schemas/MeasuredValue.json"
+        }
+      },
+      "additionalProperties": false,
+      "examples": []
+    }
+  },
+  "https://schema.org/Organization": {
+    "$id": "https://w3id.org/traceability/schemas/Organization.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$comment": {
+      "term": "Organization",
+      "@id": "https://schema.org/Organization"
+    },
+    "title": "Organization",
+    "description": "An organization such as a corporation, firm, club, etc.",
+    "classProperties": {
+      "https://schema.org/name": {
+        "$comment": {
+          "term": "name",
+          "@id": "https://schema.org/name"
+        },
+        "title": "Name",
+        "description": "Name of the organization."
+      },
+      "https://schema.org/description": {
+        "$comment": {
+          "term": "description",
+          "@id": "https://schema.org/description"
+        },
+        "title": "Description",
+        "description": "Description of the company."
+      },
+      "https://schema.org/PostalAddress": {
+        "$comment": {
+          "term": "address",
+          "@id": "https://schema.org/PostalAddress"
+        },
+        "title": "Postal Address",
+        "description": "The postal address for an organization or place."
+      },
+      "https://schema.org/email": {
+        "$comment": {
+          "term": "email",
+          "@id": "https://schema.org/email"
+        },
+        "title": "Email Address",
+        "description": "Organization's primary email address."
+      },
+      "https://schema.org/telephone": {
+        "$comment": {
+          "term": "phoneNumber",
+          "@id": "https://schema.org/telephone"
+        },
+        "title": "Phone Number",
+        "description": "Organization's contact phone number."
+      }
+    },
+    "examples": [
+      {
+        "@context": [
+          "https://w3id.org/traceability/v1"
+        ],
+        "type": "Organization",
+        "name": "Haley LLC",
+        "description": "Vision-oriented mission-critical local area network",
+        "address": {
+          "type": "PostalAddress",
+          "streetAddress": "4774 Hessel Viaduct",
+          "addressLocality": "Koelpinland",
+          "addressRegion": "West Virginia",
+          "postalCode": "10929-2431",
+          "addressCountry": "Gibraltar"
+        },
+        "email": "Garnet.Padberg@hotmail.com",
+        "phoneNumber": "1-574-531-2090 x69016"
+      },
+      {
+        "@context": [
+          "https://w3id.org/traceability/v1"
+        ],
+        "type": "Organization",
+        "name": "Mitchell, Hackett and McGlynn",
+        "description": "Focused systemic software",
+        "address": {
+          "type": "PostalAddress",
+          "streetAddress": "56339 Labadie Brooks",
+          "addressLocality": "Lake Guadalupestad",
+          "addressRegion": "Nevada",
+          "postalCode": "50842",
+          "addressCountry": "Antarctica (the territory South of 60 deg S)"
+        },
+        "email": "Brody.Stanton68@yahoo.com",
+        "phoneNumber": "612.369.8465 x805"
+      },
+      {
+        "@context": [
+          "https://w3id.org/traceability/v1"
+        ],
+        "type": "Organization",
+        "name": "Haley LLC",
+        "description": "Total leading edge conglomeration",
+        "address": {
+          "type": "PostalAddress",
+          "streetAddress": "907 Mohammad Garden",
+          "addressLocality": "North Ricky",
+          "addressRegion": "Oklahoma",
+          "postalCode": "04127-9990",
+          "addressCountry": "Maldives"
+        },
+        "email": "Lavon_Swift@hotmail.com",
+        "phoneNumber": "(748) 987-7129 x5637"
+      }
+    ],
+    "schema": {
+      "$id": "https://w3id.org/traceability/schemas/Organization.json",
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "$comment": "{\"term\": \"Organization\", \"@id\": \"https://schema.org/Organization\"}",
+      "title": "Organization",
+      "description": "An organization such as a corporation, firm, club, etc.",
+      "type": "object",
+      "properties": {
+        "@context": {
+          "type": "array"
+        },
+        "type": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array"
+            }
+          ]
+        },
+        "name": {
+          "$comment": "{\"term\": \"name\", \"@id\": \"https://schema.org/name\"}",
+          "title": "Name",
+          "description": "Name of the organization.",
+          "type": "string"
+        },
+        "description": {
+          "$comment": "{\"term\": \"description\", \"@id\": \"https://schema.org/description\"}",
+          "title": "Description",
+          "description": "Description of the company.",
+          "type": "string"
+        },
+        "address": {
+          "$comment": "{\"term\": \"address\", \"@id\": \"https://schema.org/PostalAddress\"}",
+          "title": "Postal Address",
+          "description": "The postal address for an organization or place.",
+          "$ref": "https://w3id.org/traceability/schemas/PostalAddress.json"
+        },
+        "email": {
+          "$comment": "{\"term\": \"email\", \"@id\": \"https://schema.org/email\"}",
+          "title": "Email Address",
+          "description": "Organization's primary email address.",
+          "type": "string"
+        },
+        "phoneNumber": {
+          "$comment": "{\"term\": \"phoneNumber\", \"@id\": \"https://schema.org/telephone\"}",
+          "title": "Phone Number",
+          "description": "Organization's contact phone number.",
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "examples": []
+    }
+  },
+  "https://schema.org/ParcelDelivery": {
+    "$id": "https://w3id.org/traceability/schemas/ParcelDelivery.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$comment": {
+      "term": "ParcelDelivery",
+      "@id": "https://schema.org/ParcelDelivery"
+    },
+    "title": "Parcel Delivery",
+    "description": "Details on a shipment or delivery.",
+    "classProperties": {
+      "https://schema.org/deliveryAddress": {
+        "$comment": {
+          "term": "deliveryAddress",
+          "@id": "https://schema.org/deliveryAddress"
+        },
+        "title": "Delivery Address",
+        "description": "Address to which the shipment is being sent."
+      },
+      "https://schema.org/originAddress": {
+        "$comment": {
+          "term": "originAddress",
+          "@id": "https://schema.org/originAddress"
+        },
+        "title": "Origin Address",
+        "description": "Address from where the shipment was sent."
+      },
+      "https://schema.org/trackingNumber": {
+        "$comment": {
+          "term": "trackingNumber",
+          "@id": "https://schema.org/trackingNumber"
+        },
+        "title": "Tracking Number",
+        "description": "Shipper tracking number."
+      },
+      "https://schema.org/ItemList": {
+        "$comment": {
+          "term": "products",
+          "@id": "https://schema.org/ItemList",
+          "@type": "https://schema.org/ItemList"
+        },
+        "title": "Product List",
+        "description": "List of Products"
+      }
+    },
+    "examples": [
+      {
+        "@context": [
+          "https://w3id.org/traceability/v1"
+        ],
+        "type": "ParcelDelivery",
+        "deliveryAddress": {
+          "type": "PostalAddress",
+          "organizationName": "Veum - O'Kon",
+          "streetAddress": "95908 Corwin Vista",
+          "addressLocality": "Lake Jayde",
+          "addressRegion": "Maryland",
+          "postalCode": "45737-5267",
+          "addressCountry": "Virgin Islands, U.S."
+        },
+        "originAddress": {
+          "type": "PostalAddress",
+          "organizationName": "Mraz, Keeling and Huels",
+          "streetAddress": "92784 Rice Roads",
+          "addressLocality": "Keeblershire",
+          "addressRegion": "Wyoming",
+          "postalCode": "28932",
+          "addressCountry": "Hungary"
+        },
+        "trackingNumber": "401546314975",
+        "products": [
+          {
+            "type": "Product",
+            "manufacturer": {
+              "type": "Person",
+              "firstName": "Keith",
+              "lastName": "Skiles",
+              "email": "Jon.Stiedemann41@yahoo.com",
+              "phoneNumber": "1-787-298-3130 x3469",
+              "worksFor": {
+                "type": "Organization",
+                "name": "King, Miller and Legros",
+                "description": "Right-sized tertiary definition",
+                "address": {
+                  "type": "PostalAddress",
+                  "streetAddress": "25205 Stokes Squares",
+                  "addressLocality": "West Rae",
+                  "addressRegion": "Delaware",
+                  "postalCode": "29172",
+                  "addressCountry": "Bouvet Island (Bouvetoya)"
+                },
+                "email": "Derick90@hotmail.com",
+                "phoneNumber": "715.690.4367 x8288"
+              },
+              "jobTitle": "Internal Usability Administrator"
+            },
+            "name": "Gorgeous Soft Tuna",
+            "description": "Ergonomic executive chair upholstered in bonded black leather and PVC padded seat and back for all-day comfort and support",
+            "sizeOrAmount": {
+              "type": "QuantitativeValue",
+              "unitCode": "hg/ha",
+              "value": "566"
+            },
+            "weight": {
+              "type": "QuantitativeValue",
+              "unitCode": "hg/ha",
+              "value": "7222"
+            },
+            "sku": "165788693926"
+          },
+          {
+            "type": "Product",
+            "manufacturer": {
+              "type": "Organization",
+              "name": "Keeling, Watsica and Lindgren",
+              "description": "Seamless intangible secured line",
+              "address": {
+                "type": "PostalAddress",
+                "streetAddress": "80724 Stephanie Points",
+                "addressLocality": "New Joesphburgh",
+                "addressRegion": "New Jersey",
+                "postalCode": "02802",
+                "addressCountry": "Cote d'Ivoire"
+              },
+              "email": "Ellen37@gmail.com",
+              "phoneNumber": "537.948.1856"
+            },
+            "name": "Gorgeous Fresh Chips",
+            "description": "Andy shoes are designed to keeping in mind durability as well as trends, the most stylish range of shoes & sandals",
+            "sizeOrAmount": {
+              "type": "QuantitativeValue",
+              "unitCode": "hg/ha",
+              "value": "7981"
+            },
+            "weight": {
+              "type": "QuantitativeValue",
+              "unitCode": "hg/ha",
+              "value": "4651"
+            },
+            "sku": "801948730210"
+          },
+          {
+            "type": "Product",
+            "manufacturer": {
+              "type": "Person",
+              "firstName": "Hunter",
+              "lastName": "Torphy",
+              "email": "Faye19@hotmail.com",
+              "phoneNumber": "830.908.0086 x33230",
+              "worksFor": {
+                "type": "Organization",
+                "name": "Dibbert - Rohan",
+                "description": "Future-proofed asymmetric ability",
+                "address": {
+                  "type": "PostalAddress",
+                  "streetAddress": "664 Welch Mountain",
+                  "addressLocality": "Hettingerton",
+                  "addressRegion": "Connecticut",
+                  "postalCode": "04805-8213",
+                  "addressCountry": "Cote d'Ivoire"
+                },
+                "email": "Brayan_Mitchell@yahoo.com",
+                "phoneNumber": "331-973-3810"
+              },
+              "jobTitle": "District Functionality Coordinator"
+            },
+            "name": "Ergonomic Metal Cheese",
+            "description": "The slim & simple Maple Gaming Keyboard from Dev Byte comes with a sleek body and 7- Color RGB LED Back-lighting for smart functionality",
+            "sizeOrAmount": {
+              "type": "QuantitativeValue",
+              "unitCode": "hg/ha",
+              "value": "6182"
+            },
+            "weight": {
+              "type": "QuantitativeValue",
+              "unitCode": "hg/ha",
+              "value": "3624"
+            },
+            "sku": "516906568294"
+          }
+        ]
+      },
+      {
+        "@context": [
+          "https://w3id.org/traceability/v1"
+        ],
+        "type": "ParcelDelivery",
+        "deliveryAddress": {
+          "type": "PostalAddress",
+          "organizationName": "Hickle, Green and Gulgowski",
+          "streetAddress": "6608 Lindgren Cliffs",
+          "addressLocality": "Hagenesfurt",
+          "addressRegion": "North Dakota",
+          "postalCode": "23678-7332",
+          "addressCountry": "Bermuda"
+        },
+        "originAddress": {
+          "type": "PostalAddress",
+          "organizationName": "Bogisich, Collins and Murazik",
+          "streetAddress": "1952 Noble Ville",
+          "addressLocality": "South Roel",
+          "addressRegion": "Ohio",
+          "postalCode": "40883-1681",
+          "addressCountry": "Hungary"
+        },
+        "trackingNumber": "226798274110",
+        "products": [
+          {
+            "type": "Product",
+            "manufacturer": {
+              "type": "Person",
+              "firstName": "Diego",
+              "lastName": "Kub",
+              "email": "Kory.Osinski91@yahoo.com",
+              "phoneNumber": "204-936-1185 x605",
+              "worksFor": {
+                "type": "Organization",
+                "name": "Bogisich, Bode and Grimes",
+                "description": "Public-key user-facing middleware",
+                "address": {
+                  "type": "PostalAddress",
+                  "streetAddress": "2686 Harber Forks",
+                  "addressLocality": "Luettgenchester",
+                  "addressRegion": "New Mexico",
+                  "postalCode": "42755-7680",
+                  "addressCountry": "Saint Lucia"
+                },
+                "email": "Deshawn.Reinger85@yahoo.com",
+                "phoneNumber": "579-442-4262"
+              },
+              "jobTitle": "District Markets Assistant"
+            },
+            "name": "Rustic Metal Mouse",
+            "description": "Andy shoes are designed to keeping in mind durability as well as trends, the most stylish range of shoes & sandals",
+            "sizeOrAmount": {
+              "type": "QuantitativeValue",
+              "unitCode": "hg/ha",
+              "value": "6470"
+            },
+            "weight": {
+              "type": "QuantitativeValue",
+              "unitCode": "hg/ha",
+              "value": "3983"
+            },
+            "sku": "128267951770"
+          }
+        ]
+      },
+      {
+        "@context": [
+          "https://w3id.org/traceability/v1"
+        ],
+        "type": "ParcelDelivery",
+        "deliveryAddress": {
+          "type": "PostalAddress",
+          "organizationName": "White Inc",
+          "streetAddress": "9784 Leffler Dam",
+          "addressLocality": "New Diego",
+          "addressRegion": "Oregon",
+          "postalCode": "47183-5990",
+          "addressCountry": "Tokelau"
+        },
+        "originAddress": {
+          "type": "PostalAddress",
+          "organizationName": "Koepp LLC",
+          "streetAddress": "7244 Kunde Glens",
+          "addressLocality": "Wayneborough",
+          "addressRegion": "Louisiana",
+          "postalCode": "73186",
+          "addressCountry": "Faroe Islands"
+        },
+        "trackingNumber": "210537393926",
+        "products": [
+          {
+            "type": "Product",
+            "manufacturer": {
+              "type": "Organization",
+              "name": "Connelly, Corwin and Rath",
+              "description": "Versatile homogeneous time-frame",
+              "address": {
+                "type": "PostalAddress",
+                "streetAddress": "37752 Diana Land",
+                "addressLocality": "Bergnaummouth",
+                "addressRegion": "Alaska",
+                "postalCode": "80687-0610",
+                "addressCountry": "Kuwait"
+              },
+              "email": "Vincenza.Borer@gmail.com",
+              "phoneNumber": "701-997-6375 x4126"
+            },
+            "name": "Unbranded Steel Ball",
+            "description": "The automobile layout consists of a front-engine design, with transaxle-type transmissions mounted at the rear of the engine and four wheel drive",
+            "sizeOrAmount": {
+              "type": "QuantitativeValue",
+              "unitCode": "hg/ha",
+              "value": "9891"
+            },
+            "weight": {
+              "type": "QuantitativeValue",
+              "unitCode": "hg/ha",
+              "value": "2739"
+            },
+            "sku": "405649282369"
+          },
+          {
+            "type": "Product",
+            "manufacturer": {
+              "type": "Person",
+              "firstName": "Junior",
+              "lastName": "Stoltenberg",
+              "email": "Arvel.Stehr@hotmail.com",
+              "phoneNumber": "497-729-3522",
+              "worksFor": {
+                "type": "Organization",
+                "name": "Hayes - Schaden",
+                "description": "Operative needs-based knowledge user",
+                "address": {
+                  "type": "PostalAddress",
+                  "streetAddress": "24041 Liliana Rapid",
+                  "addressLocality": "New Dewayne",
+                  "addressRegion": "Montana",
+                  "postalCode": "59084-5273",
+                  "addressCountry": "Russian Federation"
+                },
+                "email": "Frederic_Stroman39@gmail.com",
+                "phoneNumber": "567.945.4808"
+              },
+              "jobTitle": "Dynamic Research Orchestrator"
+            },
+            "name": "Handcrafted Plastic Chips",
+            "description": "Ergonomic executive chair upholstered in bonded black leather and PVC padded seat and back for all-day comfort and support",
+            "sizeOrAmount": {
+              "type": "QuantitativeValue",
+              "unitCode": "hg/ha",
+              "value": "8212"
+            },
+            "weight": {
+              "type": "QuantitativeValue",
+              "unitCode": "hg/ha",
+              "value": "3592"
+            },
+            "sku": "105269685098"
+          }
+        ]
+      }
+    ],
+    "schema": {
+      "$id": "https://w3id.org/traceability/schemas/ParcelDelivery.json",
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "$comment": "{\"term\": \"ParcelDelivery\", \"@id\": \"https://schema.org/ParcelDelivery\"}",
+      "title": "Parcel Delivery",
+      "description": "Details on a shipment or delivery.",
+      "type": "object",
+      "properties": {
+        "@context": {
+          "type": "array"
+        },
+        "type": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array"
+            }
+          ]
+        },
+        "deliveryAddress": {
+          "$comment": "{\"term\": \"deliveryAddress\", \"@id\": \"https://schema.org/deliveryAddress\"}",
+          "title": "Delivery Address",
+          "description": "Address to which the shipment is being sent.",
+          "$ref": "https://w3id.org/traceability/schemas/PostalAddress.json"
+        },
+        "originAddress": {
+          "$comment": "{\"term\": \"originAddress\", \"@id\": \"https://schema.org/originAddress\"}",
+          "title": "Origin Address",
+          "description": "Address from where the shipment was sent.",
+          "$ref": "https://w3id.org/traceability/schemas/PostalAddress.json"
+        },
+        "trackingNumber": {
+          "$comment": "{\"term\": \"trackingNumber\", \"@id\": \"https://schema.org/trackingNumber\"}",
+          "title": "Tracking Number",
+          "description": "Shipper tracking number.",
+          "type": "string"
+        },
+        "products": {
+          "$comment": "{\"term\": \"products\", \"@id\": \"https://schema.org/ItemList\", \"@type\": \"https://schema.org/ItemList\"}",
+          "title": "Product List",
+          "description": "List of Products",
+          "type": "array"
+        }
+      },
+      "additionalProperties": false,
+      "examples": []
+    }
+  },
+  "https://schema.org/Person": {
+    "$id": "https://w3id.org/traceability/schemas/Person.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$comment": {
+      "term": "Person",
+      "@id": "https://schema.org/Person"
+    },
+    "title": "Person",
+    "description": "A person",
+    "classProperties": {
+      "https://schema.org/givenName": {
+        "$comment": {
+          "term": "firstName",
+          "@id": "https://schema.org/givenName"
+        },
+        "title": "First Name",
+        "description": "Person's first name."
+      },
+      "https://schema.org/familyName": {
+        "$comment": {
+          "term": "lastName",
+          "@id": "https://schema.org/familyName"
+        },
+        "title": "Last Name",
+        "description": "Person's last name."
+      },
+      "https://schema.org/email": {
+        "$comment": {
+          "term": "email",
+          "@id": "https://schema.org/email"
+        },
+        "title": "Person's Email Address",
+        "description": "Person's email address."
+      },
+      "https://schema.org/telephone": {
+        "$comment": {
+          "term": "phoneNumber",
+          "@id": "https://schema.org/telephone"
+        },
+        "title": "Phone Number",
+        "description": "Person's contact phone number."
+      },
+      "https://schema.org/worksFor": {
+        "$comment": {
+          "term": "worksFor",
+          "@id": "https://schema.org/worksFor"
+        },
+        "title": "Works For",
+        "description": "Company which employs the person."
+      },
+      "https://schema.org/jobTitle": {
+        "$comment": {
+          "term": "jobTitle",
+          "@id": "https://schema.org/jobTitle"
+        },
+        "title": "Job Title",
+        "description": "Person's job title."
+      }
+    },
+    "examples": [
+      {
+        "@context": [
+          "https://w3id.org/traceability/v1"
+        ],
+        "type": "Person",
+        "firstName": "Reggie",
+        "lastName": "Swaniawski",
+        "email": "Abbigail_Wintheiser96@yahoo.com",
+        "phoneNumber": "1-669-877-4103",
+        "worksFor": {
+          "type": "Organization",
+          "name": "Rath, Fadel and Von",
+          "description": "Compatible responsive knowledge base",
+          "address": {
+            "type": "PostalAddress",
+            "streetAddress": "49334 Weissnat Curve",
+            "addressLocality": "East Lisandroside",
+            "addressRegion": "South Dakota",
+            "postalCode": "04081",
+            "addressCountry": "Swaziland"
+          },
+          "email": "Isobel_Kihn@hotmail.com",
+          "phoneNumber": "1-941-975-4053 x0265"
+        },
+        "jobTitle": "District Accountability Officer"
+      },
+      {
+        "@context": [
+          "https://w3id.org/traceability/v1"
+        ],
+        "type": "Person",
+        "firstName": "Layla",
+        "lastName": "Wisozk",
+        "email": "Magdalena.Orn@gmail.com",
+        "phoneNumber": "379-636-0905 x53569",
+        "worksFor": {
+          "type": "Organization",
+          "name": "Toy LLC",
+          "description": "Total background initiative",
+          "address": {
+            "type": "PostalAddress",
+            "streetAddress": "304 Jaskolski Spur",
+            "addressLocality": "Kilbacktown",
+            "addressRegion": "Louisiana",
+            "postalCode": "31843-1657",
+            "addressCountry": "Cote d'Ivoire"
+          },
+          "email": "Braden_Kilback18@hotmail.com",
+          "phoneNumber": "1-777-789-8569"
+        },
+        "jobTitle": "Investor Infrastructure Specialist"
+      },
+      {
+        "@context": [
+          "https://w3id.org/traceability/v1"
+        ],
+        "type": "Person",
+        "firstName": "Elliot",
+        "lastName": "Halvorson",
+        "email": "Richard72@hotmail.com",
+        "phoneNumber": "724.861.5735",
+        "worksFor": {
+          "type": "Organization",
+          "name": "Balistreri, Ankunding and Dach",
+          "description": "Persistent asymmetric concept",
+          "address": {
+            "type": "PostalAddress",
+            "streetAddress": "0406 Walter Flats",
+            "addressLocality": "Destiniberg",
+            "addressRegion": "Delaware",
+            "postalCode": "55182",
+            "addressCountry": "South Georgia and the South Sandwich Islands"
+          },
+          "email": "Damaris.Stracke@hotmail.com",
+          "phoneNumber": "291.512.5551"
+        },
+        "jobTitle": "Lead Division Agent"
+      }
+    ],
+    "schema": {
+      "$id": "https://w3id.org/traceability/schemas/Person.json",
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "$comment": "{\"term\": \"Person\", \"@id\": \"https://schema.org/Person\"}",
+      "title": "Person",
+      "description": "A person",
+      "type": "object",
+      "properties": {
+        "@context": {
+          "type": "array"
+        },
+        "type": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array"
+            }
+          ]
+        },
+        "firstName": {
+          "$comment": "{\"term\": \"firstName\", \"@id\": \"https://schema.org/givenName\"}",
+          "title": "First Name",
+          "description": "Person's first name.",
+          "type": "string"
+        },
+        "lastName": {
+          "$comment": "{\"term\": \"lastName\", \"@id\": \"https://schema.org/familyName\"}",
+          "title": "Last Name",
+          "description": "Person's last name.",
+          "type": "string"
+        },
+        "email": {
+          "$comment": "{\"term\": \"email\", \"@id\": \"https://schema.org/email\"}",
+          "title": "Person's Email Address",
+          "description": "Person's email address.",
+          "type": "string"
+        },
+        "phoneNumber": {
+          "$comment": "{\"term\": \"phoneNumber\", \"@id\": \"https://schema.org/telephone\"}",
+          "title": "Phone Number",
+          "description": "Person's contact phone number.",
+          "type": "string"
+        },
+        "worksFor": {
+          "$comment": "{\"term\": \"worksFor\", \"@id\": \"https://schema.org/worksFor\"}",
+          "title": "Works For",
+          "description": "Company which employs the person.",
+          "$ref": "https://w3id.org/traceability/schemas/Organization.json"
+        },
+        "jobTitle": {
+          "$comment": "{\"term\": \"jobTitle\", \"@id\": \"https://schema.org/jobTitle\"}",
+          "title": "Job Title",
+          "description": "Person's job title.",
+          "type": "string"
         }
       },
       "additionalProperties": false,
@@ -1685,6 +3098,338 @@
           "$comment": "{\"term\": \"postOfficeBoxNumber\", \"@id\": \"https://schema.org/postOfficeBoxNumber\"}",
           "title": "Post Office Box Number",
           "description": "The number that identifies a PO box. A PO box is a box in a post office or other postal service location assigned to an organization where postal items may be kept.",
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "examples": []
+    }
+  },
+  "https://schema.org/Product": {
+    "$id": "https://w3id.org/traceability/schemas/Product.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$comment": {
+      "term": "Product",
+      "@id": "https://schema.org/Product"
+    },
+    "title": "Product",
+    "description": "A product",
+    "classProperties": {
+      "https://schema.org/manufacturer": {
+        "$comment": {
+          "term": "manufacturer",
+          "@id": "https://schema.org/manufacturer"
+        },
+        "title": "Manufacturer",
+        "description": "The entity manufacturing the product."
+      },
+      "https://schema.org/name": {
+        "$comment": {
+          "term": "name",
+          "@id": "https://schema.org/name"
+        },
+        "title": "Name",
+        "description": "Name of the shipment item(s)"
+      },
+      "https://schema.org/description": {
+        "$comment": {
+          "term": "description",
+          "@id": "https://schema.org/description"
+        },
+        "title": "Description",
+        "description": "Description of the shipment."
+      },
+      "https://schema.org/size": {
+        "$comment": {
+          "term": "sizeOrAmount",
+          "@id": "https://schema.org/size"
+        },
+        "title": "Size or Amount",
+        "description": "The size or amount of the product"
+      },
+      "https://schema.org/weight": {
+        "$comment": {
+          "term": "weight",
+          "@id": "https://schema.org/weight"
+        },
+        "title": "Weight",
+        "description": "Weight of the product."
+      },
+      "https://schema.org/sku": {
+        "$comment": {
+          "term": "sku",
+          "@id": "https://schema.org/sku"
+        },
+        "title": "Sku Number",
+        "description": "The Stock Keeping Unit (SKU), i.e. a merchant-specific identifier for a product or service, or the product to which the offer refers."
+      }
+    },
+    "examples": [
+      {
+        "@context": [
+          "https://w3id.org/traceability/v1"
+        ],
+        "type": "Product",
+        "manufacturer": {
+          "type": "Person",
+          "firstName": "Jerrod",
+          "lastName": "Bogan",
+          "email": "Odessa39@gmail.com",
+          "phoneNumber": "(574) 269-8462 x579",
+          "worksFor": {
+            "type": "Organization",
+            "name": "Emmerich, Mante and Donnelly",
+            "description": "Implemented disintermediate groupware",
+            "address": {
+              "type": "PostalAddress",
+              "streetAddress": "45308 Jaycee Vista",
+              "addressLocality": "Eusebiofort",
+              "addressRegion": "South Dakota",
+              "postalCode": "30949-9264",
+              "addressCountry": "Estonia"
+            },
+            "email": "Claude_Kihn26@yahoo.com",
+            "phoneNumber": "683-380-4851"
+          },
+          "jobTitle": "Corporate Data Orchestrator"
+        },
+        "name": "Sleek Frozen Mouse",
+        "description": "The Nagasaki Lander is the trademarked name of several series of Nagasaki sport bikes, that started with the 1984 ABC800J",
+        "sizeOrAmount": {
+          "type": "QuantitativeValue",
+          "unitCode": "hg/ha",
+          "value": "5912"
+        },
+        "weight": {
+          "type": "QuantitativeValue",
+          "unitCode": "hg/ha",
+          "value": "8206"
+        },
+        "sku": "43632142035"
+      },
+      {
+        "@context": [
+          "https://w3id.org/traceability/v1"
+        ],
+        "type": "Product",
+        "manufacturer": {
+          "type": "Person",
+          "firstName": "Yazmin",
+          "lastName": "Abernathy",
+          "email": "Sven.Schmeler@yahoo.com",
+          "phoneNumber": "(488) 716-9876 x18990",
+          "worksFor": {
+            "type": "Organization",
+            "name": "Dietrich - Reichel",
+            "description": "Reduced web-enabled extranet",
+            "address": {
+              "type": "PostalAddress",
+              "streetAddress": "3646 Aurelie Point",
+              "addressLocality": "Tessieberg",
+              "addressRegion": "Oregon",
+              "postalCode": "28003-5169",
+              "addressCountry": "Sao Tome and Principe"
+            },
+            "email": "Gideon4@yahoo.com",
+            "phoneNumber": "870.993.9296"
+          },
+          "jobTitle": "National Brand Director"
+        },
+        "name": "Unbranded Plastic Hat",
+        "description": "The Apollotech B340 is an affordable wireless mouse with reliable connectivity, 12 months battery life and modern design",
+        "sizeOrAmount": {
+          "type": "QuantitativeValue",
+          "unitCode": "hg/ha",
+          "value": "3306"
+        },
+        "weight": {
+          "type": "QuantitativeValue",
+          "unitCode": "hg/ha",
+          "value": "2452"
+        },
+        "sku": "407472905958"
+      },
+      {
+        "@context": [
+          "https://w3id.org/traceability/v1"
+        ],
+        "type": "Product",
+        "manufacturer": {
+          "type": "Organization",
+          "name": "Sanford - Legros",
+          "description": "Cross-group content-based migration",
+          "address": {
+            "type": "PostalAddress",
+            "streetAddress": "291 Torp Summit",
+            "addressLocality": "Americaport",
+            "addressRegion": "Tennessee",
+            "postalCode": "23280",
+            "addressCountry": "Spain"
+          },
+          "email": "Selmer_Upton43@hotmail.com",
+          "phoneNumber": "(872) 937-5989"
+        },
+        "name": "Sleek Wooden Sausages",
+        "description": "Andy shoes are designed to keeping in mind durability as well as trends, the most stylish range of shoes & sandals",
+        "sizeOrAmount": {
+          "type": "QuantitativeValue",
+          "unitCode": "hg/ha",
+          "value": "8972"
+        },
+        "weight": {
+          "type": "QuantitativeValue",
+          "unitCode": "hg/ha",
+          "value": "3156"
+        },
+        "sku": "475876054302"
+      }
+    ],
+    "schema": {
+      "$id": "https://w3id.org/traceability/schemas/Product.json",
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "$comment": "{\"term\": \"Product\", \"@id\": \"https://schema.org/Product\"}",
+      "title": "Product",
+      "description": "A product",
+      "type": "object",
+      "properties": {
+        "@context": {
+          "type": "array"
+        },
+        "type": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array"
+            }
+          ]
+        },
+        "manufacturer": {
+          "$comment": "{\"term\": \"manufacturer\", \"@id\": \"https://schema.org/manufacturer\"}",
+          "title": "Manufacturer",
+          "description": "The entity manufacturing the product.",
+          "$ref": "https://w3id.org/traceability/schemas/Entity.json"
+        },
+        "name": {
+          "$comment": "{\"term\": \"name\", \"@id\": \"https://schema.org/name\"}",
+          "title": "Name",
+          "description": "Name of the shipment item(s)",
+          "type": "string"
+        },
+        "description": {
+          "$comment": "{\"term\": \"description\", \"@id\": \"https://schema.org/description\"}",
+          "title": "Description",
+          "description": "Description of the shipment.",
+          "type": "string"
+        },
+        "sizeOrAmount": {
+          "$comment": "{\"term\": \"sizeOrAmount\", \"@id\": \"https://schema.org/size\"}",
+          "title": "Size or Amount",
+          "description": "The size or amount of the product",
+          "$ref": "https://w3id.org/traceability/schemas/QuantitativeValue.json"
+        },
+        "weight": {
+          "$comment": "{\"term\": \"weight\", \"@id\": \"https://schema.org/weight\"}",
+          "title": "Weight",
+          "description": "Weight of the product.",
+          "$ref": "https://w3id.org/traceability/schemas/QuantitativeValue.json"
+        },
+        "sku": {
+          "$comment": "{\"term\": \"sku\", \"@id\": \"https://schema.org/sku\"}",
+          "title": "Sku Number",
+          "description": "The Stock Keeping Unit (SKU), i.e. a merchant-specific identifier for a product or service, or the product to which the offer refers.",
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "examples": []
+    }
+  },
+  "https://schema.org/QuantitativeValue": {
+    "$id": "https://w3id.org/traceability/schemas/QuantitativeValue.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$comment": {
+      "term": "QuantitativeValue",
+      "@id": "https://schema.org/QuantitativeValue"
+    },
+    "title": "Quantitative Value",
+    "description": "A point value or interval for product characteristics and other purposes",
+    "classProperties": {
+      "https://schema.org/unitCode": {
+        "$comment": {
+          "term": "unitCode",
+          "@id": "https://schema.org/unitCode"
+        },
+        "title": "Unit Code",
+        "description": "Unit of measurement."
+      },
+      "https://schema.org/value": {
+        "$comment": {
+          "term": "value",
+          "@id": "https://schema.org/value"
+        },
+        "title": "Value",
+        "description": "Value or amount."
+      }
+    },
+    "examples": [
+      {
+        "@context": [
+          "https://w3id.org/traceability/v1"
+        ],
+        "type": "QuantitativeValue",
+        "unitCode": "hg/ha",
+        "value": "7845"
+      },
+      {
+        "@context": [
+          "https://w3id.org/traceability/v1"
+        ],
+        "type": "QuantitativeValue",
+        "unitCode": "hg/ha",
+        "value": "7816"
+      },
+      {
+        "@context": [
+          "https://w3id.org/traceability/v1"
+        ],
+        "type": "QuantitativeValue",
+        "unitCode": "hg/ha",
+        "value": "6399"
+      }
+    ],
+    "schema": {
+      "$id": "https://w3id.org/traceability/schemas/QuantitativeValue.json",
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "$comment": "{\"term\": \"QuantitativeValue\", \"@id\": \"https://schema.org/QuantitativeValue\"}",
+      "title": "Quantitative Value",
+      "description": "A point value or interval for product characteristics and other purposes",
+      "type": "object",
+      "properties": {
+        "@context": {
+          "type": "array"
+        },
+        "type": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array"
+            }
+          ]
+        },
+        "unitCode": {
+          "$comment": "{\"term\": \"unitCode\", \"@id\": \"https://schema.org/unitCode\"}",
+          "title": "Unit Code",
+          "description": "Unit of measurement.",
+          "type": "string"
+        },
+        "value": {
+          "$comment": "{\"term\": \"value\", \"@id\": \"https://schema.org/value\"}",
+          "title": "Value",
+          "description": "Value or amount.",
           "type": "string"
         }
       },

--- a/docs/schemas/AgInspectionReport.json
+++ b/docs/schemas/AgInspectionReport.json
@@ -20,13 +20,13 @@
       ]
     },
     "facility": {
-      "$comment": "{\"term\": \"facility\", \"@id\": \"https://schema.org/Place\"}",
+      "$comment": "{\"term\": \"facility\", \"@id\": \"https://w3id.org/traceability/schemas/Place.json\"}",
       "title": "Facility Identifier",
       "description": "Identifiers for an inspection facility.",
       "$ref": "https://w3id.org/traceability/schemas/Place.json"
     },
     "inspector": {
-      "$comment": "{\"term\": \"inspector\", \"@id\": \"https://w3id.org/traceability/schemas/inspector\"}",
+      "$comment": "{\"term\": \"inspector\", \"@id\": \"https://w3id.org/traceability/schemas/Inspector\"}",
       "title": "Inspector",
       "description": "Inspector performing the Aggriculture Inspection",
       "$ref": "https://w3id.org/traceability/schemas/Inspector.json"
@@ -35,13 +35,13 @@
       "$comment": "{\"term\": \"shipment\", \"@id\": \"https://schema.org/ParcelDelivery\"}",
       "title": "Shipment",
       "description": "Details for a shipment of goods.",
-      "$ref": "https://schema.org/version/latest/schemaorg-current-http.jsonld#https://schema.org/ParcelDelivery"
+      "$ref": "https://w3id.org/traceability/schemas/ParcelDelivery.json"
     },
-    "applicantId": {
-      "$comment": "{\"term\": \"applicantId\", \"@id\": \"https://schema.org/identifier\"}",
-      "title": "Applicant Identifier",
-      "description": "Identifiers for the entity inspection applicant.",
-      "type": "string"
+    "applicant": {
+      "$comment": "{\"term\": \"applicant\", \"@id\": \"https://w3id.org/traceability/schemas/Entity\"}",
+      "title": "Applicant",
+      "description": "Entity that is applying for the inspection.",
+      "$ref": "https://w3id.org/traceability/schemas/Entity.json"
     },
     "inspectionDate": {
       "$comment": "{\"term\": \"inspectionDate\", \"@id\": \"https://schema.org/DateTime\"}",

--- a/docs/schemas/Entity.json
+++ b/docs/schemas/Entity.json
@@ -1,0 +1,16 @@
+{
+    "$id": "https://w3id.org/traceability/schemas/Entity.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$comment": "{\"term\": \"Entity\", \"@id\": \"https://w3id.org/traceability/Entity\"}",
+    "title": "Entity",
+    "description": "A person or organization.",
+    "anyOf": [
+        {
+            "$ref": "https://w3id.org/traceability/schemas/Person.json"
+        },
+        {
+            "$ref": "https://w3id.org/traceability/schemas/Organization.json"
+        }
+    ],
+    "examples": []
+}

--- a/docs/schemas/Inspector.json
+++ b/docs/schemas/Inspector.json
@@ -20,10 +20,10 @@
             ]
         },
         "person": {
-            "$comment": "{\"term\": \"person\", \"@id\": \"https://schema.org/Person\"}",
+            "$comment": "{\"term\": \"person\", \"@id\": \"https://w3id.org/traceability/schemas/Person.json\"}",
             "title": "Person",
             "description": "Person doing the inspection.",
-            "type": "string"
+            "$ref": "https://w3id.org/traceability/schemas/Person.json"
         },
         "credential": {
             "$comment": "{\"term\": \"credential\", \"@id\": \"https://schema.org/ItemList\", \"@type\": \"https://schema.org/ItemList\"}",

--- a/docs/schemas/Organization.json
+++ b/docs/schemas/Organization.json
@@ -1,0 +1,55 @@
+{
+    "$id": "https://w3id.org/traceability/schemas/Organization.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$comment": "{\"term\": \"Organization\", \"@id\": \"https://schema.org/Organization\"}",
+    "title": "Organization",
+    "description": "An organization such as a corporation, firm, club, etc.",
+    "type": "object",
+    "properties": {
+        "@context": {
+            "type": "array"
+        },
+        "type": {
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "array"
+                }
+            ]
+        },
+        "name": {
+            "$comment": "{\"term\": \"name\", \"@id\": \"https://schema.org/name\"}",
+            "title": "Name",
+            "description": "Name of the organization.",
+            "type": "string"
+        },
+        "description": {
+            "$comment": "{\"term\": \"description\", \"@id\": \"https://schema.org/description\"}",
+            "title": "Description",
+            "description": "Description of the company.",
+            "type": "string"
+        },
+        "address": {
+            "$comment": "{\"term\": \"address\", \"@id\": \"https://schema.org/PostalAddress\"}",
+            "title": "Postal Address",
+            "description": "The postal address for an organization or place.",
+            "$ref": "https://w3id.org/traceability/schemas/PostalAddress.json"
+        },
+        "email": {
+            "$comment": "{\"term\": \"email\", \"@id\": \"https://schema.org/email\"}",
+            "title": "Email Address",
+            "description": "Organization's primary email address.",
+            "type": "string"
+        },
+        "phoneNumber": {
+            "$comment": "{\"term\": \"phoneNumber\", \"@id\": \"https://schema.org/telephone\"}",
+            "title": "Phone Number",
+            "description": "Organization's contact phone number.",
+            "type": "string"
+        }
+    },
+    "additionalProperties": false,
+    "examples": []
+}

--- a/docs/schemas/ParcelDelivery.json
+++ b/docs/schemas/ParcelDelivery.json
@@ -1,0 +1,49 @@
+{
+    "$id": "https://w3id.org/traceability/schemas/ParcelDelivery.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$comment": "{\"term\": \"ParcelDelivery\", \"@id\": \"https://schema.org/ParcelDelivery\"}",
+    "title": "Parcel Delivery",
+    "description": "Details on a shipment or delivery.",
+    "type": "object",
+    "properties": {
+        "@context": {
+            "type": "array"
+        },
+        "type": {
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "array"
+                }
+            ]
+        },
+        "deliveryAddress": {
+            "$comment": "{\"term\": \"deliveryAddress\", \"@id\": \"https://schema.org/deliveryAddress\"}",
+            "title": "Delivery Address",
+            "description": "Address to which the shipment is being sent.",
+            "$ref": "https://w3id.org/traceability/schemas/PostalAddress.json"
+        },
+        "originAddress": {
+            "$comment": "{\"term\": \"originAddress\", \"@id\": \"https://schema.org/originAddress\"}",
+            "title": "Origin Address",
+            "description": "Address from where the shipment was sent.",
+            "$ref": "https://w3id.org/traceability/schemas/PostalAddress.json"
+        },
+        "trackingNumber": {
+            "$comment": "{\"term\": \"trackingNumber\", \"@id\": \"https://schema.org/trackingNumber\"}",
+            "title": "Tracking Number",
+            "description": "Shipper tracking number.",
+            "type": "string"
+        },
+        "products": {
+            "$comment": "{\"term\": \"products\", \"@id\": \"https://schema.org/ItemList\", \"@type\": \"https://schema.org/ItemList\"}",
+            "title": "Product List",
+            "description": "List of Products",
+            "type": "array"
+        }
+    },
+    "additionalProperties": false,
+    "examples": []
+}

--- a/docs/schemas/Person.json
+++ b/docs/schemas/Person.json
@@ -1,0 +1,61 @@
+{
+    "$id": "https://w3id.org/traceability/schemas/Person.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$comment": "{\"term\": \"Person\", \"@id\": \"https://schema.org/Person\"}",
+    "title": "Person",
+    "description": "A person",
+    "type": "object",
+    "properties": {
+        "@context": {
+            "type": "array"
+        },
+        "type": {
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "array"
+                }
+            ]
+        },
+        "firstName": {
+            "$comment": "{\"term\": \"firstName\", \"@id\": \"https://schema.org/givenName\"}",
+            "title": "First Name",
+            "description": "Person's first name.",
+            "type": "string"
+        },
+        "lastName": {
+            "$comment": "{\"term\": \"lastName\", \"@id\": \"https://schema.org/familyName\"}",
+            "title": "Last Name",
+            "description": "Person's last name.",
+            "type": "string"
+        },
+        "email": {
+            "$comment": "{\"term\": \"email\", \"@id\": \"https://schema.org/email\"}",
+            "title": "Person's Email Address",
+            "description": "Person's email address.",
+            "type": "string"
+        },
+        "phoneNumber": {
+            "$comment": "{\"term\": \"phoneNumber\", \"@id\": \"https://schema.org/telephone\"}",
+            "title": "Phone Number",
+            "description": "Person's contact phone number.",
+            "type": "string"
+        },
+        "worksFor": {
+            "$comment": "{\"term\": \"worksFor\", \"@id\": \"https://schema.org/worksFor\"}",
+            "title": "Works For",
+            "description": "Company which employs the person.",
+            "$ref": "https://w3id.org/traceability/schemas/Organization.json"
+        },
+        "jobTitle": {
+            "$comment": "{\"term\": \"jobTitle\", \"@id\": \"https://schema.org/jobTitle\"}",
+            "title": "Job Title",
+            "description": "Person's job title.",
+            "type": "string"
+        }
+    },
+    "additionalProperties": false,
+    "examples": []
+}

--- a/docs/schemas/Product.json
+++ b/docs/schemas/Product.json
@@ -1,0 +1,61 @@
+{
+    "$id": "https://w3id.org/traceability/schemas/Product.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$comment": "{\"term\": \"Product\", \"@id\": \"https://schema.org/Product\"}",
+    "title": "Product",
+    "description": "A product",
+    "type": "object",
+    "properties": {
+        "@context": {
+            "type": "array"
+        },
+        "type": {
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "array"
+                }
+            ]
+        },
+        "manufacturer": {
+            "$comment": "{\"term\": \"manufacturer\", \"@id\": \"https://schema.org/manufacturer\"}",
+            "title": "Manufacturer",
+            "description": "The entity manufacturing the product.",
+            "$ref": "https://w3id.org/traceability/schemas/Entity.json"
+        },
+        "name": {
+            "$comment": "{\"term\": \"name\", \"@id\": \"https://schema.org/name\"}",
+            "title": "Name",
+            "description": "Name of the shipment item(s)",
+            "type": "string"
+        },
+        "description": {
+            "$comment": "{\"term\": \"description\", \"@id\": \"https://schema.org/description\"}",
+            "title": "Description",
+            "description": "Description of the shipment.",
+            "type": "string"
+        },
+        "sizeOrAmount": {
+            "$comment": "{\"term\": \"sizeOrAmount\", \"@id\": \"https://schema.org/size\"}",
+            "title": "Size or Amount",
+            "description": "The size or amount of the product",
+            "$ref": "https://w3id.org/traceability/schemas/QuantitativeValue.json"
+        },
+        "weight": {
+            "$comment": "{\"term\": \"weight\", \"@id\": \"https://schema.org/weight\"}",
+            "title": "Weight",
+            "description": "Weight of the product.",
+            "$ref": "https://w3id.org/traceability/schemas/QuantitativeValue.json"
+        },
+        "sku": {
+            "$comment": "{\"term\": \"sku\", \"@id\": \"https://schema.org/sku\"}",
+            "title": "Sku Number",
+            "description": "The Stock Keeping Unit (SKU), i.e. a merchant-specific identifier for a product or service, or the product to which the offer refers.",
+            "type": "string"
+        }
+    },
+    "additionalProperties": false,
+    "examples": []
+}

--- a/docs/schemas/QuantitativeValue.json
+++ b/docs/schemas/QuantitativeValue.json
@@ -1,0 +1,37 @@
+{
+    "$id": "https://w3id.org/traceability/schemas/QuantitativeValue.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$comment": "{\"term\": \"QuantitativeValue\", \"@id\": \"https://schema.org/QuantitativeValue\"}",
+    "title": "Quantitative Value",
+    "description": "A point value or interval for product characteristics and other purposes",
+    "type": "object",
+    "properties": {
+        "@context": {
+            "type": "array"
+        },
+        "type": {
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "array"
+                }
+            ]
+        },
+        "unitCode": {
+            "$comment": "{\"term\": \"unitCode\", \"@id\": \"https://schema.org/unitCode\"}",
+            "title": "Unit Code",
+            "description": "Unit of measurement.",
+            "type": "string"
+        },
+        "value": {
+            "$comment": "{\"term\": \"value\", \"@id\": \"https://schema.org/value\"}",
+            "title": "Value",
+            "description": "Value or amount.",
+            "type": "string"
+        }
+    },
+    "additionalProperties": false,
+    "examples": []
+}

--- a/docs/test-vectors/AgInspectionReport.json
+++ b/docs/test-vectors/AgInspectionReport.json
@@ -7,172 +7,167 @@
       "type": "AgInspectionReport",
       "facility": {
         "type": "Place",
-        "globalLocationNumber": "9101318209329",
+        "globalLocationNumber": "5094112557724",
         "geo": {
           "type": "GeoCoordinates",
-          "latitude": "-62.7434",
-          "longitude": "-162.4415"
+          "latitude": "6.9367",
+          "longitude": "70.2528"
         },
         "address": {
           "type": "PostalAddress",
-          "organizationName": "Luettgen - Kris",
-          "streetAddress": "8593 Alejandra Stream",
-          "addressLocality": "Toymouth",
-          "addressRegion": "Florida",
-          "postalCode": "39338-8131",
-          "addressCountry": "Benin"
+          "organizationName": "Swift - Larkin",
+          "streetAddress": "1167 Nelle Wells",
+          "addressLocality": "Caroleville",
+          "addressRegion": "North Carolina",
+          "postalCode": "17085-4582",
+          "addressCountry": "Puerto Rico"
         }
       },
       "inspector": {
         "type": "Inspector",
-        "person": "Janice Franecki",
-        "credential": [
-          {
-            "type": "Credential",
-            "credentialCategory": "Dynamic Program Agent",
-            "credentialValue": "Specialist"
+        "person": {
+          "type": "Person",
+          "firstName": "Sofia",
+          "lastName": "Runolfsdottir",
+          "email": "Edgardo17@hotmail.com",
+          "phoneNumber": "(874) 571-1664 x187",
+          "worksFor": {
+            "type": "Organization",
+            "name": "Conroy, Herman and Kreiger",
+            "description": "Quality-focused bifurcated moratorium",
+            "address": {
+              "type": "PostalAddress",
+              "streetAddress": "066 Rahul Squares",
+              "addressLocality": "D'Amorefurt",
+              "addressRegion": "Delaware",
+              "postalCode": "16365-8130",
+              "addressCountry": "Croatia"
+            },
+            "email": "Elinor64@gmail.com",
+            "phoneNumber": "(501) 413-3480 x274"
           },
-          {
-            "type": "Credential",
-            "credentialCategory": "Dynamic Group Assistant",
-            "credentialValue": "Manager"
-          },
-          {
-            "type": "Credential",
-            "credentialCategory": "Direct Response Facilitator",
-            "credentialValue": "Executive"
-          }
-        ]
-      },
-      "shipment": {
-        "sku": 633855376147,
-        "itemShipped": "Mangoes, mangosteens, guavas",
-        "provider": "Hessel LLC"
-      },
-      "applicantId": 148140,
-      "inspectionDate": "10-3-2020",
-      "inspectionType": "General",
-      "observation": [
-        {
-          "type": "Observation",
-          "property": {
-            "type": "ChemicalProperty",
-            "name": "Radon",
-            "formula": "Rn",
-            "inchi": "InChI=1S/Rn",
-            "inchikey": "SYUHGPGVQRZVTB-UHFFFAOYSA-N"
-          },
-          "measurement": {
-            "value": "100.00",
-            "unitCode": "P1"
-          }
-        }
-      ]
-    },
-    {
-      "@context": [
-        "https://w3id.org/traceability/v1"
-      ],
-      "type": "AgInspectionReport",
-      "facility": {
-        "type": "Place",
-        "globalLocationNumber": "3336842677948",
-        "geo": {
-          "type": "GeoCoordinates",
-          "latitude": "42.9655",
-          "longitude": "172.2708"
+          "jobTitle": "Direct Mobility Officer"
         },
-        "address": {
-          "type": "PostalAddress",
-          "organizationName": "Mraz, Keeling and Huels",
-          "streetAddress": "92784 Rice Roads",
-          "addressLocality": "Keeblershire",
-          "addressRegion": "Wyoming",
-          "postalCode": "28932",
-          "addressCountry": "Hungary"
-        }
-      },
-      "inspector": {
-        "type": "Inspector",
-        "person": "Dr. Bertha Grant",
         "credential": [
           {
             "type": "Credential",
-            "credentialCategory": "Product Branding Orchestrator",
+            "credentialCategory": "District Infrastructure Specialist",
+            "credentialValue": "Agent"
+          },
+          {
+            "type": "Credential",
+            "credentialCategory": "National Implementation Coordinator",
             "credentialValue": "Technician"
-          },
-          {
-            "type": "Credential",
-            "credentialCategory": "Corporate Marketing Manager",
-            "credentialValue": "Designer"
-          },
-          {
-            "type": "Credential",
-            "credentialCategory": "Dynamic Security Planner",
-            "credentialValue": "Consultant"
           }
         ]
       },
       "shipment": {
-        "sku": 486040206538,
-        "itemShipped": "Avocados",
-        "provider": "Will Inc"
+        "type": "ParcelDelivery",
+        "deliveryAddress": {
+          "type": "PostalAddress",
+          "organizationName": "Ortiz, Pouros and Steuber",
+          "streetAddress": "0553 Xander Parkway",
+          "addressLocality": "South Skye",
+          "addressRegion": "Connecticut",
+          "postalCode": "86326",
+          "addressCountry": "Iraq"
+        },
+        "originAddress": {
+          "type": "PostalAddress",
+          "organizationName": "Boyle, Hane and Corkery",
+          "streetAddress": "987 Cameron Valley",
+          "addressLocality": "New Electaburgh",
+          "addressRegion": "Nevada",
+          "postalCode": "48332-0620",
+          "addressCountry": "Gibraltar"
+        },
+        "trackingNumber": "503164088156",
+        "products": [
+          {
+            "type": "Product",
+            "manufacturer": {
+              "type": "Organization",
+              "name": "Heaney - Grady",
+              "description": "Reverse-engineered client-driven matrix",
+              "address": {
+                "type": "PostalAddress",
+                "streetAddress": "1870 Hintz Terrace",
+                "addressLocality": "South Abbey",
+                "addressRegion": "Iowa",
+                "postalCode": "42210",
+                "addressCountry": "Republic of Korea"
+              },
+              "email": "Brock.Hartmann82@yahoo.com",
+              "phoneNumber": "461-525-5187 x42208"
+            },
+            "name": "Small Plastic Bacon",
+            "description": "Carbonite web goalkeeper gloves are ergonomically designed to give easy fit",
+            "sizeOrAmount": {
+              "type": "QuantitativeValue",
+              "unitCode": "hg/ha",
+              "value": "6178"
+            },
+            "weight": {
+              "type": "QuantitativeValue",
+              "unitCode": "hg/ha",
+              "value": "5960"
+            },
+            "sku": "88259203676"
+          }
+        ]
       },
-      "applicantId": 7174114,
-      "inspectionDate": "10-3-2020",
-      "inspectionType": "General",
+      "applicant": {
+        "type": "Person",
+        "firstName": "Jaylon",
+        "lastName": "Bradtke",
+        "email": "Zane_Pollich39@yahoo.com",
+        "phoneNumber": "847-262-8755",
+        "worksFor": {
+          "type": "Organization",
+          "name": "Gaylord, Brown and Kunde",
+          "description": "Persevering interactive protocol",
+          "address": {
+            "type": "PostalAddress",
+            "streetAddress": "657 Beverly Hills",
+            "addressLocality": "Rogahnfurt",
+            "addressRegion": "New Mexico",
+            "postalCode": "73208",
+            "addressCountry": "Iran"
+          },
+          "email": "Jana_Hagenes@gmail.com",
+          "phoneNumber": "1-731-783-9434 x174"
+        },
+        "jobTitle": "Central Paradigm Facilitator"
+      },
+      "inspectionDate": "11-2-2020",
+      "inspectionType": "Phytosanitary",
       "observation": [
         {
           "type": "Observation",
           "property": {
-            "type": "MechanicalProperty",
-            "identifier": "ISO 180",
-            "name": "Izod Impact Strength Test",
-            "description": "ISO 180 defines the method used for pendulums to determine the impact resistance of a plastic specimen when supported in a cantilever configuration. Test results are used to evaluate the resilience of materials, typically plastics."
-          },
-          "measurement": {
-            "value": "15.279",
-            "unitCode": "B13"
-          }
-        },
-        {
-          "type": "Observation",
-          "property": {
-            "type": "MechanicalProperty",
-            "identifier": "ISO 180",
-            "name": "Izod Impact Strength Test",
-            "description": "ISO 180 defines the method used for pendulums to determine the impact resistance of a plastic specimen when supported in a cantilever configuration. Test results are used to evaluate the resilience of materials, typically plastics."
-          },
-          "measurement": {
-            "value": "39.757",
-            "unitCode": "B13"
-          }
-        },
-        {
-          "type": "Observation",
-          "property": {
             "type": "ChemicalProperty",
-            "name": "Actinium",
-            "formula": "Ac",
-            "inchi": "InChI=1S/Ac",
-            "inchikey": "QQINRWTZWGJFDB-UHFFFAOYSA-N"
+            "name": "Ruthenium",
+            "formula": "Ru",
+            "inchi": "InChI=1S/Ru",
+            "inchikey": "KJTLSVCANCCWHF-UHFFFAOYSA-N"
           },
           "measurement": {
-            "value": "100.00",
+            "value": "88.180",
             "unitCode": "P1"
           }
         },
         {
           "type": "Observation",
           "property": {
-            "type": "MechanicalProperty",
-            "identifier": "ISO 3738",
-            "name": "Rockwell Hardness Test (Scale A)",
-            "description": "The Rockwell hardness test is an empirical indentation hardness test that can provide useful information about metallic materials."
+            "type": "ChemicalProperty",
+            "name": "Lawrencium",
+            "formula": "Lr",
+            "inchi": "InChI=1S/Lr",
+            "inchikey": "CNQCVBJFEGMYDW-UHFFFAOYSA-N"
           },
           "measurement": {
-            "value": "00.00",
-            "unitCode": "UNKNOWN"
+            "value": "11.820",
+            "unitCode": "P1"
           }
         }
       ]
@@ -184,71 +179,416 @@
       "type": "AgInspectionReport",
       "facility": {
         "type": "Place",
-        "globalLocationNumber": "9264939189811",
+        "globalLocationNumber": "5461635410698",
         "geo": {
           "type": "GeoCoordinates",
-          "latitude": "-17.0945",
-          "longitude": "-63.8361"
+          "latitude": "9.6831",
+          "longitude": "38.8686"
         },
         "address": {
           "type": "PostalAddress",
-          "organizationName": "Ritchie, Shanahan and Graham",
-          "streetAddress": "858 Ryan Overpass",
-          "addressLocality": "DuBuquebury",
-          "addressRegion": "Oklahoma",
-          "postalCode": "87198-3130",
-          "addressCountry": "Haiti"
+          "organizationName": "Veum - Tillman",
+          "streetAddress": "43086 Margaret Parks",
+          "addressLocality": "Ritchiemouth",
+          "addressRegion": "South Carolina",
+          "postalCode": "34553-8056",
+          "addressCountry": "Taiwan"
         }
       },
       "inspector": {
         "type": "Inspector",
-        "person": "Robin Nitzsche",
+        "person": {
+          "type": "Person",
+          "firstName": "Lucio",
+          "lastName": "Bosco",
+          "email": "Nedra_Beahan@gmail.com",
+          "phoneNumber": "493.926.1850 x981",
+          "worksFor": {
+            "type": "Organization",
+            "name": "Herman, Langworth and Shanahan",
+            "description": "Integrated dedicated methodology",
+            "address": {
+              "type": "PostalAddress",
+              "streetAddress": "41419 Metz Camp",
+              "addressLocality": "Lake Althea",
+              "addressRegion": "Virginia",
+              "postalCode": "93531",
+              "addressCountry": "Gambia"
+            },
+            "email": "Melvin_Wisozk@hotmail.com",
+            "phoneNumber": "1-907-898-1822 x31897"
+          },
+          "jobTitle": "Dynamic Infrastructure Technician"
+        },
         "credential": [
           {
             "type": "Credential",
-            "credentialCategory": "Dynamic Factors Assistant",
-            "credentialValue": "Representative"
-          },
-          {
-            "type": "Credential",
-            "credentialCategory": "District Intranet Associate",
-            "credentialValue": "Assistant"
+            "credentialCategory": "Forward Mobility Agent",
+            "credentialValue": "Orchestrator"
           }
         ]
       },
       "shipment": {
-        "sku": 165788693926,
-        "itemShipped": "Taro (cocoyam)",
-        "provider": "Funk, Price and Waters"
+        "type": "ParcelDelivery",
+        "deliveryAddress": {
+          "type": "PostalAddress",
+          "organizationName": "Williamson - Tromp",
+          "streetAddress": "399 Demetris Dam",
+          "addressLocality": "West Malloryborough",
+          "addressRegion": "Wisconsin",
+          "postalCode": "17952-8678",
+          "addressCountry": "Guatemala"
+        },
+        "originAddress": {
+          "type": "PostalAddress",
+          "organizationName": "Johns, Krajcik and Windler",
+          "streetAddress": "938 Bednar Locks",
+          "addressLocality": "East Noelshire",
+          "addressRegion": "Ohio",
+          "postalCode": "15758",
+          "addressCountry": "Denmark"
+        },
+        "trackingNumber": "551197846908",
+        "products": [
+          {
+            "type": "Product",
+            "manufacturer": {
+              "type": "Person",
+              "firstName": "Russell",
+              "lastName": "Lehner",
+              "email": "Dell20@yahoo.com",
+              "phoneNumber": "820.558.7250",
+              "worksFor": {
+                "type": "Organization",
+                "name": "Durgan - Brown",
+                "description": "Devolved global monitoring",
+                "address": {
+                  "type": "PostalAddress",
+                  "streetAddress": "8055 Gerlach Roads",
+                  "addressLocality": "Port Sibyl",
+                  "addressRegion": "Louisiana",
+                  "postalCode": "61304-3589",
+                  "addressCountry": "Azerbaijan"
+                },
+                "email": "Diana_Bartoletti@yahoo.com",
+                "phoneNumber": "1-924-561-8943"
+              },
+              "jobTitle": "Dynamic Security Facilitator"
+            },
+            "name": "Tasty Steel Gloves",
+            "description": "Carbonite web goalkeeper gloves are ergonomically designed to give easy fit",
+            "sizeOrAmount": {
+              "type": "QuantitativeValue",
+              "unitCode": "hg/ha",
+              "value": "2393"
+            },
+            "weight": {
+              "type": "QuantitativeValue",
+              "unitCode": "hg/ha",
+              "value": "5415"
+            },
+            "sku": "950856140054"
+          }
+        ]
       },
-      "applicantId": 2823292,
-      "inspectionDate": "10-3-2020",
-      "inspectionType": "Contamination",
+      "applicant": {
+        "type": "Person",
+        "firstName": "Alverta",
+        "lastName": "Jacobs",
+        "email": "Brayan_Veum@yahoo.com",
+        "phoneNumber": "1-753-463-1245 x04543",
+        "worksFor": {
+          "type": "Organization",
+          "name": "Hyatt Group",
+          "description": "Customer-focused value-added interface",
+          "address": {
+            "type": "PostalAddress",
+            "streetAddress": "21199 Keely Squares",
+            "addressLocality": "Binsberg",
+            "addressRegion": "Indiana",
+            "postalCode": "85119-2230",
+            "addressCountry": "Saint Barthelemy"
+          },
+          "email": "Chadrick.Carter@yahoo.com",
+          "phoneNumber": "1-947-251-7218"
+        },
+        "jobTitle": "National Tactics Technician"
+      },
+      "inspectionDate": "11-2-2020",
+      "inspectionType": "Phytosanitary",
       "observation": [
         {
           "type": "Observation",
           "property": {
             "type": "ChemicalProperty",
-            "name": "Zinc",
-            "formula": "Zn",
-            "inchi": "InChI=1S/Zn",
-            "inchikey": "HCHKCACWOHOZIP-UHFFFAOYSA-N"
+            "name": "Iodine",
+            "formula": "I",
+            "inchi": "InChI=1S/I",
+            "inchikey": "ZCYVEMRRCGMTRW-UHFFFAOYSA-N"
           },
           "measurement": {
-            "value": "100.00",
+            "value": "35.694",
             "unitCode": "P1"
           }
         },
         {
           "type": "Observation",
           "property": {
-            "type": "MechanicalProperty",
-            "identifier": "ISO 148",
-            "name": "Charpy Impact Strength Test",
-            "description": "ISO 148-1:2016 specifies the Charpy (V-notch and U-notch) pendulum impact test method for determining the energy absorbed in an impact test of metallic materials. This part of ISO 148 does not cover instrumented impact testing, which is specified in ISO 14556."
+            "type": "ChemicalProperty",
+            "name": "Strontium",
+            "formula": "Sr",
+            "inchi": "InChI=1S/Sr",
+            "inchikey": "CIOAGBVUUVVLOB-UHFFFAOYSA-N"
           },
           "measurement": {
-            "value": "58.590",
+            "value": "42.049",
+            "unitCode": "P1"
+          }
+        },
+        {
+          "type": "Observation",
+          "property": {
+            "type": "ChemicalProperty",
+            "name": "Helium",
+            "formula": "He",
+            "inchi": "InChI=1S/He",
+            "inchikey": "SWQJXJOGLNCZEY-UHFFFAOYSA-N"
+          },
+          "measurement": {
+            "value": "1.1345",
+            "unitCode": "P1"
+          }
+        },
+        {
+          "type": "Observation",
+          "property": {
+            "type": "ChemicalProperty",
+            "name": "Platinum",
+            "formula": "Pt",
+            "inchi": "InChI=1S/Pt",
+            "inchikey": "BASFCYQUMIYNBI-UHFFFAOYSA-N"
+          },
+          "measurement": {
+            "value": "21.122",
+            "unitCode": "P1"
+          }
+        }
+      ]
+    },
+    {
+      "@context": [
+        "https://w3id.org/traceability/v1"
+      ],
+      "type": "AgInspectionReport",
+      "facility": {
+        "type": "Place",
+        "globalLocationNumber": "4013194867881",
+        "geo": {
+          "type": "GeoCoordinates",
+          "latitude": "-25.5339",
+          "longitude": "-153.9454"
+        },
+        "address": {
+          "type": "PostalAddress",
+          "organizationName": "Bashirian - Bode",
+          "streetAddress": "6204 Abe Port",
+          "addressLocality": "Gorczanyside",
+          "addressRegion": "California",
+          "postalCode": "24005",
+          "addressCountry": "Kenya"
+        }
+      },
+      "inspector": {
+        "type": "Inspector",
+        "person": {
+          "type": "Person",
+          "firstName": "Michele",
+          "lastName": "Rosenbaum",
+          "email": "Addie76@hotmail.com",
+          "phoneNumber": "334-491-6248 x09191",
+          "worksFor": {
+            "type": "Organization",
+            "name": "Smith, Stroman and Kuhlman",
+            "description": "Profit-focused interactive neural-net",
+            "address": {
+              "type": "PostalAddress",
+              "streetAddress": "779 Gottlieb Port",
+              "addressLocality": "New Hilariotown",
+              "addressRegion": "Florida",
+              "postalCode": "13297-1232",
+              "addressCountry": "Hong Kong"
+            },
+            "email": "Katelyn_Gleichner@yahoo.com",
+            "phoneNumber": "(826) 938-4901"
+          },
+          "jobTitle": "Human Factors Officer"
+        },
+        "credential": [
+          {
+            "type": "Credential",
+            "credentialCategory": "Central Integration Director",
+            "credentialValue": "Officer"
+          },
+          {
+            "type": "Credential",
+            "credentialCategory": "Dynamic Data Architect",
+            "credentialValue": "Representative"
+          }
+        ]
+      },
+      "shipment": {
+        "type": "ParcelDelivery",
+        "deliveryAddress": {
+          "type": "PostalAddress",
+          "organizationName": "Bogisich - Gibson",
+          "streetAddress": "6276 Huels Parkways",
+          "addressLocality": "East Harmony",
+          "addressRegion": "South Dakota",
+          "postalCode": "12101",
+          "addressCountry": "Antarctica (the territory South of 60 deg S)"
+        },
+        "originAddress": {
+          "type": "PostalAddress",
+          "organizationName": "Mayer and Sons",
+          "streetAddress": "027 Hermiston Groves",
+          "addressLocality": "Nikolausborough",
+          "addressRegion": "Rhode Island",
+          "postalCode": "55608",
+          "addressCountry": "Ecuador"
+        },
+        "trackingNumber": "377822965748",
+        "products": [
+          {
+            "type": "Product",
+            "manufacturer": {
+              "type": "Organization",
+              "name": "Carroll and Sons",
+              "description": "Reduced stable hub",
+              "address": {
+                "type": "PostalAddress",
+                "streetAddress": "5515 Dibbert Fall",
+                "addressLocality": "West Myrtie",
+                "addressRegion": "Alaska",
+                "postalCode": "74404-9344",
+                "addressCountry": "Netherlands"
+              },
+              "email": "Willow.Labadie46@gmail.com",
+              "phoneNumber": "1-378-469-2484 x931"
+            },
+            "name": "Gorgeous Concrete Shirt",
+            "description": "Ergonomic executive chair upholstered in bonded black leather and PVC padded seat and back for all-day comfort and support",
+            "sizeOrAmount": {
+              "type": "QuantitativeValue",
+              "unitCode": "hg/ha",
+              "value": "9030"
+            },
+            "weight": {
+              "type": "QuantitativeValue",
+              "unitCode": "hg/ha",
+              "value": "5692"
+            },
+            "sku": "738393217334"
+          },
+          {
+            "type": "Product",
+            "manufacturer": {
+              "type": "Organization",
+              "name": "Turner, Kihn and Crona",
+              "description": "Public-key full-range open architecture",
+              "address": {
+                "type": "PostalAddress",
+                "streetAddress": "412 Elsa Plain",
+                "addressLocality": "Schillerside",
+                "addressRegion": "Kansas",
+                "postalCode": "07159",
+                "addressCountry": "Nigeria"
+              },
+              "email": "Anabelle.Rohan43@hotmail.com",
+              "phoneNumber": "1-456-889-9848"
+            },
+            "name": "Gorgeous Rubber Table",
+            "description": "The beautiful range of Apple Naturalé that has an exciting mix of natural ingredients. With the Goodness of 100% Natural Ingredients",
+            "sizeOrAmount": {
+              "type": "QuantitativeValue",
+              "unitCode": "hg/ha",
+              "value": "8920"
+            },
+            "weight": {
+              "type": "QuantitativeValue",
+              "unitCode": "hg/ha",
+              "value": "6527"
+            },
+            "sku": "819915551842"
+          },
+          {
+            "type": "Product",
+            "manufacturer": {
+              "type": "Person",
+              "firstName": "Demarco",
+              "lastName": "Turcotte",
+              "email": "Pietro_McCullough@gmail.com",
+              "phoneNumber": "1-492-931-1296",
+              "worksFor": {
+                "type": "Organization",
+                "name": "Mertz, Labadie and Lindgren",
+                "description": "Face to face composite structure",
+                "address": {
+                  "type": "PostalAddress",
+                  "streetAddress": "052 Chaz Fort",
+                  "addressLocality": "Hellerton",
+                  "addressRegion": "Pennsylvania",
+                  "postalCode": "44591",
+                  "addressCountry": "Sierra Leone"
+                },
+                "email": "Asia99@gmail.com",
+                "phoneNumber": "401-762-5146"
+              },
+              "jobTitle": "Customer Functionality Orchestrator"
+            },
+            "name": "Handmade Rubber Pizza",
+            "description": "Andy shoes are designed to keeping in mind durability as well as trends, the most stylish range of shoes & sandals",
+            "sizeOrAmount": {
+              "type": "QuantitativeValue",
+              "unitCode": "hg/ha",
+              "value": "2979"
+            },
+            "weight": {
+              "type": "QuantitativeValue",
+              "unitCode": "hg/ha",
+              "value": "8985"
+            },
+            "sku": "234438850760"
+          }
+        ]
+      },
+      "applicant": {
+        "type": "Organization",
+        "name": "Botsford and Sons",
+        "description": "Configurable empowering flexibility",
+        "address": {
+          "type": "PostalAddress",
+          "streetAddress": "222 Cruickshank Ville",
+          "addressLocality": "West Marielle",
+          "addressRegion": "Michigan",
+          "postalCode": "45148",
+          "addressCountry": "Guadeloupe"
+        },
+        "email": "Shanon.Marvin51@hotmail.com",
+        "phoneNumber": "1-282-246-1499 x7539"
+      },
+      "inspectionDate": "11-1-2020",
+      "inspectionType": "General",
+      "observation": [
+        {
+          "type": "Observation",
+          "property": {
+            "type": "MechanicalProperty",
+            "identifier": "ISO 180",
+            "name": "Izod Impact Strength Test",
+            "description": "ISO 180 defines the method used for pendulums to determine the impact resistance of a plastic specimen when supported in a cantilever configuration. Test results are used to evaluate the resilience of materials, typically plastics."
+          },
+          "measurement": {
+            "value": "81.647",
             "unitCode": "B13"
           }
         }
@@ -257,8 +597,295 @@
   ],
   "bad": [
     {
-      "alarm": "back up",
-      "capacitor": "generate"
+      "@context": [
+        "https://w3id.org/traceability/v1"
+      ],
+      "facility": {
+        "type": "Place",
+        "globalLocationNumber": "5094112557724",
+        "geo": {
+          "type": "GeoCoordinates",
+          "latitude": "6.9367",
+          "longitude": "70.2528"
+        },
+        "address": {
+          "type": "PostalAddress",
+          "organizationName": "Swift - Larkin",
+          "streetAddress": "1167 Nelle Wells",
+          "addressLocality": "Caroleville",
+          "addressRegion": "North Carolina",
+          "postalCode": "17085-4582",
+          "addressCountry": "Puerto Rico"
+        }
+      },
+      "inspector": {
+        "type": "Inspector",
+        "person": {
+          "type": "Person",
+          "firstName": "Sofia",
+          "lastName": "Runolfsdottir",
+          "email": "Edgardo17@hotmail.com",
+          "phoneNumber": "(874) 571-1664 x187",
+          "worksFor": {
+            "type": "Organization",
+            "name": "Conroy, Herman and Kreiger",
+            "description": "Quality-focused bifurcated moratorium",
+            "address": {
+              "type": "PostalAddress",
+              "streetAddress": "066 Rahul Squares",
+              "addressLocality": "D'Amorefurt",
+              "addressRegion": "Delaware",
+              "postalCode": "16365-8130",
+              "addressCountry": "Croatia"
+            },
+            "email": "Elinor64@gmail.com",
+            "phoneNumber": "(501) 413-3480 x274"
+          },
+          "jobTitle": "Direct Mobility Officer"
+        },
+        "credential": [
+          {
+            "type": "Credential",
+            "credentialCategory": "District Infrastructure Specialist",
+            "credentialValue": "Agent"
+          },
+          {
+            "type": "Credential",
+            "credentialCategory": "National Implementation Coordinator",
+            "credentialValue": "Technician"
+          }
+        ]
+      },
+      "shipment": {
+        "type": "ParcelDelivery",
+        "deliveryAddress": {
+          "type": "PostalAddress",
+          "organizationName": "Ortiz, Pouros and Steuber",
+          "streetAddress": "0553 Xander Parkway",
+          "addressLocality": "South Skye",
+          "addressRegion": "Connecticut",
+          "postalCode": "86326",
+          "addressCountry": "Iraq"
+        },
+        "originAddress": {
+          "type": "PostalAddress",
+          "organizationName": "Boyle, Hane and Corkery",
+          "streetAddress": "987 Cameron Valley",
+          "addressLocality": "New Electaburgh",
+          "addressRegion": "Nevada",
+          "postalCode": "48332-0620",
+          "addressCountry": "Gibraltar"
+        },
+        "trackingNumber": "503164088156",
+        "products": [
+          {
+            "type": "Product",
+            "manufacturer": {
+              "type": "Organization",
+              "name": "Heaney - Grady",
+              "description": "Reverse-engineered client-driven matrix",
+              "address": {
+                "type": "PostalAddress",
+                "streetAddress": "1870 Hintz Terrace",
+                "addressLocality": "South Abbey",
+                "addressRegion": "Iowa",
+                "postalCode": "42210",
+                "addressCountry": "Republic of Korea"
+              },
+              "email": "Brock.Hartmann82@yahoo.com",
+              "phoneNumber": "461-525-5187 x42208"
+            },
+            "name": "Small Plastic Bacon",
+            "description": "Carbonite web goalkeeper gloves are ergonomically designed to give easy fit",
+            "sizeOrAmount": {
+              "type": "QuantitativeValue",
+              "unitCode": "hg/ha",
+              "value": "6178"
+            },
+            "weight": {
+              "type": "QuantitativeValue",
+              "unitCode": "hg/ha",
+              "value": "5960"
+            },
+            "sku": "88259203676"
+          }
+        ]
+      },
+      "applicant": {
+        "type": "Person",
+        "firstName": "Jaylon",
+        "lastName": "Bradtke",
+        "email": "Zane_Pollich39@yahoo.com",
+        "phoneNumber": "847-262-8755",
+        "worksFor": {
+          "type": "Organization",
+          "name": "Gaylord, Brown and Kunde",
+          "description": "Persevering interactive protocol",
+          "address": {
+            "type": "PostalAddress",
+            "streetAddress": "657 Beverly Hills",
+            "addressLocality": "Rogahnfurt",
+            "addressRegion": "New Mexico",
+            "postalCode": "73208",
+            "addressCountry": "Iran"
+          },
+          "email": "Jana_Hagenes@gmail.com",
+          "phoneNumber": "1-731-783-9434 x174"
+        },
+        "jobTitle": "Central Paradigm Facilitator"
+      },
+      "inspectionDate": "11-2-2020",
+      "inspectionType": "Phytosanitary",
+      "observation": [
+        {
+          "type": "Observation",
+          "property": {
+            "type": "ChemicalProperty",
+            "name": "Ruthenium",
+            "formula": "Ru",
+            "inchi": "InChI=1S/Ru",
+            "inchikey": "KJTLSVCANCCWHF-UHFFFAOYSA-N"
+          },
+          "measurement": {
+            "value": "88.180",
+            "unitCode": "P1"
+          }
+        },
+        {
+          "type": "Observation",
+          "property": {
+            "type": "ChemicalProperty",
+            "name": "Lawrencium",
+            "formula": "Lr",
+            "inchi": "InChI=1S/Lr",
+            "inchikey": "CNQCVBJFEGMYDW-UHFFFAOYSA-N"
+          },
+          "measurement": {
+            "value": "11.820",
+            "unitCode": "P1"
+          }
+        }
+      ],
+      "transmitter": "reboot"
+    },
+    {
+      "type": "AgInspectionReport",
+      "facility": {
+        "type": "Place",
+        "globalLocationNumber": "5461635410698",
+        "geo": {
+          "type": "GeoCoordinates",
+          "latitude": "9.6831",
+          "longitude": "38.8686"
+        },
+        "address": {
+          "type": "PostalAddress",
+          "organizationName": "Veum - Tillman",
+          "streetAddress": "43086 Margaret Parks",
+          "addressLocality": "Ritchiemouth",
+          "addressRegion": "South Carolina",
+          "postalCode": "34553-8056",
+          "addressCountry": "Taiwan"
+        }
+      },
+      "inspector": {
+        "type": "Inspector",
+        "person": {
+          "type": "Person",
+          "firstName": "Lucio",
+          "lastName": "Bosco",
+          "email": "Nedra_Beahan@gmail.com",
+          "phoneNumber": "493.926.1850 x981",
+          "worksFor": {
+            "type": "Organization",
+            "name": "Herman, Langworth and Shanahan",
+            "description": "Integrated dedicated methodology",
+            "address": {
+              "type": "PostalAddress",
+              "streetAddress": "41419 Metz Camp",
+              "addressLocality": "Lake Althea",
+              "addressRegion": "Virginia",
+              "postalCode": "93531",
+              "addressCountry": "Gambia"
+            },
+            "email": "Melvin_Wisozk@hotmail.com",
+            "phoneNumber": "1-907-898-1822 x31897"
+          },
+          "jobTitle": "Dynamic Infrastructure Technician"
+        },
+        "credential": [
+          {
+            "type": "Credential",
+            "credentialCategory": "Forward Mobility Agent",
+            "credentialValue": "Orchestrator"
+          }
+        ]
+      },
+      "shipment": {
+        "type": "ParcelDelivery",
+        "deliveryAddress": {
+          "type": "PostalAddress",
+          "organizationName": "Williamson - Tromp",
+          "streetAddress": "399 Demetris Dam",
+          "addressLocality": "West Malloryborough",
+          "addressRegion": "Wisconsin",
+          "postalCode": "17952-8678",
+          "addressCountry": "Guatemala"
+        },
+        "originAddress": {
+          "type": "PostalAddress",
+          "organizationName": "Johns, Krajcik and Windler",
+          "streetAddress": "938 Bednar Locks",
+          "addressLocality": "East Noelshire",
+          "addressRegion": "Ohio",
+          "postalCode": "15758",
+          "addressCountry": "Denmark"
+        },
+        "trackingNumber": "551197846908",
+        "products": [
+          {
+            "type": "Product",
+            "manufacturer": {
+              "type": "Person",
+              "firstName": "Russell",
+              "lastName": "Lehner",
+              "email": "Dell20@yahoo.com",
+              "phoneNumber": "820.558.7250",
+              "worksFor": {
+                "type": "Organization",
+                "name": "Durgan - Brown",
+                "description": "Devolved global monitoring",
+                "address": {
+                  "type": "PostalAddress",
+                  "streetAddress": "8055 Gerlach Roads",
+                  "addressLocality": "Port Sibyl",
+                  "addressRegion": "Louisiana",
+                  "postalCode": "61304-3589",
+                  "addressCountry": "Azerbaijan"
+                },
+                "email": "Diana_Bartoletti@yahoo.com",
+                "phoneNumber": "1-924-561-8943"
+              },
+              "jobTitle": "Dynamic Security Facilitator"
+            },
+            "name": "Tasty Steel Gloves",
+            "description": "Carbonite web goalkeeper gloves are ergonomically designed to give easy fit",
+            "sizeOrAmount": {
+              "type": "QuantitativeValue",
+              "unitCode": "hg/ha",
+              "value": "2393"
+            },
+            "weight": {
+              "type": "QuantitativeValue",
+              "unitCode": "hg/ha",
+              "value": "5415"
+            },
+            "sku": "950856140054"
+          }
+        ]
+      },
+      "inspectionType": "Phytosanitary",
+      "hard drive": "program"
     },
     {
       "@context": [
@@ -266,58 +893,220 @@
       ],
       "facility": {
         "type": "Place",
-        "globalLocationNumber": "3336842677948",
+        "globalLocationNumber": "4013194867881",
         "geo": {
           "type": "GeoCoordinates",
-          "latitude": "42.9655",
-          "longitude": "172.2708"
+          "latitude": "-25.5339",
+          "longitude": "-153.9454"
         },
         "address": {
           "type": "PostalAddress",
-          "organizationName": "Mraz, Keeling and Huels",
-          "streetAddress": "92784 Rice Roads",
-          "addressLocality": "Keeblershire",
-          "addressRegion": "Wyoming",
-          "postalCode": "28932",
-          "addressCountry": "Hungary"
+          "organizationName": "Bashirian - Bode",
+          "streetAddress": "6204 Abe Port",
+          "addressLocality": "Gorczanyside",
+          "addressRegion": "California",
+          "postalCode": "24005",
+          "addressCountry": "Kenya"
         }
       },
       "inspector": {
         "type": "Inspector",
-        "person": "Dr. Bertha Grant",
+        "person": {
+          "type": "Person",
+          "firstName": "Michele",
+          "lastName": "Rosenbaum",
+          "email": "Addie76@hotmail.com",
+          "phoneNumber": "334-491-6248 x09191",
+          "worksFor": {
+            "type": "Organization",
+            "name": "Smith, Stroman and Kuhlman",
+            "description": "Profit-focused interactive neural-net",
+            "address": {
+              "type": "PostalAddress",
+              "streetAddress": "779 Gottlieb Port",
+              "addressLocality": "New Hilariotown",
+              "addressRegion": "Florida",
+              "postalCode": "13297-1232",
+              "addressCountry": "Hong Kong"
+            },
+            "email": "Katelyn_Gleichner@yahoo.com",
+            "phoneNumber": "(826) 938-4901"
+          },
+          "jobTitle": "Human Factors Officer"
+        },
         "credential": [
           {
             "type": "Credential",
-            "credentialCategory": "Product Branding Orchestrator",
-            "credentialValue": "Technician"
+            "credentialCategory": "Central Integration Director",
+            "credentialValue": "Officer"
           },
           {
             "type": "Credential",
-            "credentialCategory": "Corporate Marketing Manager",
-            "credentialValue": "Designer"
-          },
-          {
-            "type": "Credential",
-            "credentialCategory": "Dynamic Security Planner",
-            "credentialValue": "Consultant"
+            "credentialCategory": "Dynamic Data Architect",
+            "credentialValue": "Representative"
           }
         ]
       },
       "shipment": {
-        "sku": 486040206538,
-        "itemShipped": "Avocados",
-        "provider": "Will Inc"
+        "type": "ParcelDelivery",
+        "deliveryAddress": {
+          "type": "PostalAddress",
+          "organizationName": "Bogisich - Gibson",
+          "streetAddress": "6276 Huels Parkways",
+          "addressLocality": "East Harmony",
+          "addressRegion": "South Dakota",
+          "postalCode": "12101",
+          "addressCountry": "Antarctica (the territory South of 60 deg S)"
+        },
+        "originAddress": {
+          "type": "PostalAddress",
+          "organizationName": "Mayer and Sons",
+          "streetAddress": "027 Hermiston Groves",
+          "addressLocality": "Nikolausborough",
+          "addressRegion": "Rhode Island",
+          "postalCode": "55608",
+          "addressCountry": "Ecuador"
+        },
+        "trackingNumber": "377822965748",
+        "products": [
+          {
+            "type": "Product",
+            "manufacturer": {
+              "type": "Organization",
+              "name": "Carroll and Sons",
+              "description": "Reduced stable hub",
+              "address": {
+                "type": "PostalAddress",
+                "streetAddress": "5515 Dibbert Fall",
+                "addressLocality": "West Myrtie",
+                "addressRegion": "Alaska",
+                "postalCode": "74404-9344",
+                "addressCountry": "Netherlands"
+              },
+              "email": "Willow.Labadie46@gmail.com",
+              "phoneNumber": "1-378-469-2484 x931"
+            },
+            "name": "Gorgeous Concrete Shirt",
+            "description": "Ergonomic executive chair upholstered in bonded black leather and PVC padded seat and back for all-day comfort and support",
+            "sizeOrAmount": {
+              "type": "QuantitativeValue",
+              "unitCode": "hg/ha",
+              "value": "9030"
+            },
+            "weight": {
+              "type": "QuantitativeValue",
+              "unitCode": "hg/ha",
+              "value": "5692"
+            },
+            "sku": "738393217334"
+          },
+          {
+            "type": "Product",
+            "manufacturer": {
+              "type": "Organization",
+              "name": "Turner, Kihn and Crona",
+              "description": "Public-key full-range open architecture",
+              "address": {
+                "type": "PostalAddress",
+                "streetAddress": "412 Elsa Plain",
+                "addressLocality": "Schillerside",
+                "addressRegion": "Kansas",
+                "postalCode": "07159",
+                "addressCountry": "Nigeria"
+              },
+              "email": "Anabelle.Rohan43@hotmail.com",
+              "phoneNumber": "1-456-889-9848"
+            },
+            "name": "Gorgeous Rubber Table",
+            "description": "The beautiful range of Apple Naturalé that has an exciting mix of natural ingredients. With the Goodness of 100% Natural Ingredients",
+            "sizeOrAmount": {
+              "type": "QuantitativeValue",
+              "unitCode": "hg/ha",
+              "value": "8920"
+            },
+            "weight": {
+              "type": "QuantitativeValue",
+              "unitCode": "hg/ha",
+              "value": "6527"
+            },
+            "sku": "819915551842"
+          },
+          {
+            "type": "Product",
+            "manufacturer": {
+              "type": "Person",
+              "firstName": "Demarco",
+              "lastName": "Turcotte",
+              "email": "Pietro_McCullough@gmail.com",
+              "phoneNumber": "1-492-931-1296",
+              "worksFor": {
+                "type": "Organization",
+                "name": "Mertz, Labadie and Lindgren",
+                "description": "Face to face composite structure",
+                "address": {
+                  "type": "PostalAddress",
+                  "streetAddress": "052 Chaz Fort",
+                  "addressLocality": "Hellerton",
+                  "addressRegion": "Pennsylvania",
+                  "postalCode": "44591",
+                  "addressCountry": "Sierra Leone"
+                },
+                "email": "Asia99@gmail.com",
+                "phoneNumber": "401-762-5146"
+              },
+              "jobTitle": "Customer Functionality Orchestrator"
+            },
+            "name": "Handmade Rubber Pizza",
+            "description": "Andy shoes are designed to keeping in mind durability as well as trends, the most stylish range of shoes & sandals",
+            "sizeOrAmount": {
+              "type": "QuantitativeValue",
+              "unitCode": "hg/ha",
+              "value": "2979"
+            },
+            "weight": {
+              "type": "QuantitativeValue",
+              "unitCode": "hg/ha",
+              "value": "8985"
+            },
+            "sku": "234438850760"
+          }
+        ]
       },
-      "applicantId": 7174114,
-      "inspectionDate": "10-3-2020",
+      "applicant": {
+        "type": "Organization",
+        "name": "Botsford and Sons",
+        "description": "Configurable empowering flexibility",
+        "address": {
+          "type": "PostalAddress",
+          "streetAddress": "222 Cruickshank Ville",
+          "addressLocality": "West Marielle",
+          "addressRegion": "Michigan",
+          "postalCode": "45148",
+          "addressCountry": "Guadeloupe"
+        },
+        "email": "Shanon.Marvin51@hotmail.com",
+        "phoneNumber": "1-282-246-1499 x7539"
+      },
+      "inspectionDate": "11-1-2020",
       "inspectionType": "General",
-      "pixel": "generate",
-      "application": "reboot"
-    },
-    {
-      "card": "quantify",
-      "panel": "back up",
-      "port": "transmit"
+      "observation": [
+        {
+          "type": "Observation",
+          "property": {
+            "type": "MechanicalProperty",
+            "identifier": "ISO 180",
+            "name": "Izod Impact Strength Test",
+            "description": "ISO 180 defines the method used for pendulums to determine the impact resistance of a plastic specimen when supported in a cantilever configuration. Test results are used to evaluate the resilience of materials, typically plastics."
+          },
+          "measurement": {
+            "value": "81.647",
+            "unitCode": "B13"
+          }
+        }
+      ],
+      "driver": "navigate",
+      "transmitter": "input",
+      "interface": "generate"
     }
   ]
 }

--- a/docs/test-vectors/Credential.json
+++ b/docs/test-vectors/Credential.json
@@ -5,48 +5,45 @@
         "https://w3id.org/traceability/v1"
       ],
       "type": "Credential",
-      "credentialCategory": "Forward Quality Officer",
-      "credentialValue": "Engineer"
+      "credentialCategory": "Senior Creative Facilitator",
+      "credentialValue": "Manager"
     },
     {
       "@context": [
         "https://w3id.org/traceability/v1"
       ],
       "type": "Credential",
-      "credentialCategory": "International Response Specialist",
-      "credentialValue": "Architect"
+      "credentialCategory": "Senior Functionality Manager",
+      "credentialValue": "Strategist"
     },
     {
       "@context": [
         "https://w3id.org/traceability/v1"
       ],
       "type": "Credential",
-      "credentialCategory": "Principal Infrastructure Technician",
-      "credentialValue": "Specialist"
+      "credentialCategory": "Customer Optimization Producer",
+      "credentialValue": "Administrator"
     }
   ],
   "bad": [
     {
-      "@context": [
-        "https://w3id.org/traceability/v1"
-      ],
-      "array": "connect",
-      "hard drive": "synthesize"
+      "capacitor": "transmit",
+      "panel": "synthesize",
+      "application": "program"
     },
     {
-      "@context": [
-        "https://w3id.org/traceability/v1"
-      ],
       "type": "Credential",
-      "credentialCategory": "International Response Specialist",
-      "monitor": "input",
-      "transmitter": "back up",
-      "port": "calculate",
-      "application": "hack"
+      "credentialCategory": "Senior Functionality Manager",
+      "credentialValue": "Strategist",
+      "interface": "override",
+      "card": "calculate",
+      "capacitor": "override"
     },
     {
-      "credentialCategory": "Principal Infrastructure Technician",
-      "circuit": "quantify"
+      "credentialCategory": "Customer Optimization Producer",
+      "credentialValue": "Administrator",
+      "driver": "transmit",
+      "panel": "reboot"
     }
   ]
 }

--- a/docs/test-vectors/Entity.json
+++ b/docs/test-vectors/Entity.json
@@ -1,0 +1,93 @@
+{
+  "good": [
+    {
+      "@context": [
+        "https://w3id.org/traceability/v1"
+      ],
+      "type": "Organization",
+      "name": "Buckridge Group",
+      "description": "Enhanced human-resource benchmark",
+      "address": {
+        "type": "PostalAddress",
+        "streetAddress": "2711 Nikki Keys",
+        "addressLocality": "South Ryannville",
+        "addressRegion": "Alaska",
+        "postalCode": "85791",
+        "addressCountry": "Poland"
+      },
+      "email": "Raymundo_Hodkiewicz@yahoo.com",
+      "phoneNumber": "228-474-2165 x665"
+    },
+    {
+      "@context": [
+        "https://w3id.org/traceability/v1"
+      ],
+      "type": "Organization",
+      "name": "Orn Group",
+      "description": "Phased coherent pricing structure",
+      "address": {
+        "type": "PostalAddress",
+        "streetAddress": "616 Marques Mill",
+        "addressLocality": "Lemkeshire",
+        "addressRegion": "Oregon",
+        "postalCode": "10226-9002",
+        "addressCountry": "Nigeria"
+      },
+      "email": "Kyler_Kris@hotmail.com",
+      "phoneNumber": "1-763-272-9022 x4456"
+    },
+    {
+      "@context": [
+        "https://w3id.org/traceability/v1"
+      ],
+      "type": "Organization",
+      "name": "Ernser, Lang and Herzog",
+      "description": "Synchronised intermediate interface",
+      "address": {
+        "type": "PostalAddress",
+        "streetAddress": "65406 O'Connell Light",
+        "addressLocality": "Kiehnberg",
+        "addressRegion": "Indiana",
+        "postalCode": "66751-4608",
+        "addressCountry": "Eritrea"
+      },
+      "email": "Wilton.Grady46@yahoo.com",
+      "phoneNumber": "1-878-785-3627"
+    }
+  ],
+  "bad": [
+    {
+      "address": {
+        "type": "PostalAddress",
+        "streetAddress": "2711 Nikki Keys",
+        "addressLocality": "South Ryannville",
+        "addressRegion": "Alaska",
+        "postalCode": "85791",
+        "addressCountry": "Poland"
+      },
+      "phoneNumber": "228-474-2165 x665",
+      "firewall": "override",
+      "transmitter": "program",
+      "circuit": "reboot"
+    },
+    {
+      "name": "Orn Group",
+      "email": "Kyler_Kris@hotmail.com",
+      "phoneNumber": "1-763-272-9022 x4456",
+      "panel": "hack"
+    },
+    {
+      "name": "Ernser, Lang and Herzog",
+      "address": {
+        "type": "PostalAddress",
+        "streetAddress": "65406 O'Connell Light",
+        "addressLocality": "Kiehnberg",
+        "addressRegion": "Indiana",
+        "postalCode": "66751-4608",
+        "addressCountry": "Eritrea"
+      },
+      "bus": "reboot",
+      "sensor": "parse"
+    }
+  ]
+}

--- a/docs/test-vectors/InspectionReport.json
+++ b/docs/test-vectors/InspectionReport.json
@@ -10,19 +10,6 @@
           "type": "Observation",
           "property": {
             "type": "MechanicalProperty",
-            "identifier": "ISO 148",
-            "name": "Charpy Impact Strength Test",
-            "description": "ISO 148-1:2016 specifies the Charpy (V-notch and U-notch) pendulum impact test method for determining the energy absorbed in an impact test of metallic materials. This part of ISO 148 does not cover instrumented impact testing, which is specified in ISO 14556."
-          },
-          "measurement": {
-            "value": "24.720",
-            "unitCode": "B13"
-          }
-        },
-        {
-          "type": "Observation",
-          "property": {
-            "type": "MechanicalProperty",
             "identifier": "ISO 3738",
             "name": "Rockwell Hardness Test (Scale A)",
             "description": "The Rockwell hardness test is an empirical indentation hardness test that can provide useful information about metallic materials."
@@ -30,196 +17,6 @@
           "measurement": {
             "value": "00.00",
             "unitCode": "UNKNOWN"
-          }
-        },
-        {
-          "type": "Observation",
-          "property": {
-            "type": "ChemicalProperty",
-            "name": "Nihonium",
-            "formula": "Nh"
-          },
-          "measurement": {
-            "value": "00.00",
-            "unitCode": "UNKNOWN"
-          }
-        },
-        {
-          "type": "Observation",
-          "property": {
-            "type": "MechanicalProperty",
-            "identifier": "ISO 148",
-            "name": "Charpy Impact Strength Test",
-            "description": "ISO 148-1:2016 specifies the Charpy (V-notch and U-notch) pendulum impact test method for determining the energy absorbed in an impact test of metallic materials. This part of ISO 148 does not cover instrumented impact testing, which is specified in ISO 14556."
-          },
-          "measurement": {
-            "value": "66.711",
-            "unitCode": "B13"
-          }
-        },
-        {
-          "type": "Observation",
-          "property": {
-            "type": "ChemicalProperty",
-            "name": "Thulium",
-            "formula": "Tm",
-            "inchi": "InChI=1S/Tm",
-            "inchikey": "FRNOGLGSGLTDKL-UHFFFAOYSA-N"
-          },
-          "measurement": {
-            "value": "31.503",
-            "unitCode": "P1"
-          }
-        },
-        {
-          "type": "Observation",
-          "property": {
-            "type": "MechanicalProperty",
-            "identifier": "ISO 3738",
-            "name": "Rockwell Hardness Test (Scale A)",
-            "description": "The Rockwell hardness test is an empirical indentation hardness test that can provide useful information about metallic materials."
-          },
-          "measurement": {
-            "value": "00.00",
-            "unitCode": "UNKNOWN"
-          }
-        },
-        {
-          "type": "Observation",
-          "property": {
-            "type": "MechanicalProperty",
-            "identifier": "ISO 1352",
-            "name": "Torque-controlled fatigue testing",
-            "description": "ISO 1352:2011 specifies the conditions for performing torsional, constant-amplitude, nominally elastic stress fatigue tests on metallic specimens without deliberately introducing stress concentrations. The tests are carried out at ambient temperature (ideally at between 10 °C and 35 °C) in air by applying a pure couple to the specimen about its longitudinal axis."
-          },
-          "measurement": {
-            "value": "00.00",
-            "unitCode": "UNKNOWN"
-          }
-        },
-        {
-          "type": "Observation",
-          "property": {
-            "type": "MechanicalProperty",
-            "identifier": "ISO 3738",
-            "name": "Rockwell Hardness Test (Scale A)",
-            "description": "The Rockwell hardness test is an empirical indentation hardness test that can provide useful information about metallic materials."
-          },
-          "measurement": {
-            "value": "00.00",
-            "unitCode": "UNKNOWN"
-          }
-        },
-        {
-          "type": "Observation",
-          "property": {
-            "type": "ChemicalProperty",
-            "name": "Boron",
-            "formula": "B",
-            "inchi": "InChI=1S/B",
-            "inchikey": "ZOXJGFHDIHLPTG-UHFFFAOYSA-N"
-          },
-          "measurement": {
-            "value": "68.497",
-            "unitCode": "P1"
-          }
-        }
-      ]
-    },
-    {
-      "@context": [
-        "https://w3id.org/traceability/v1"
-      ],
-      "type": "InspectionReport",
-      "observation": [
-        {
-          "type": "Observation",
-          "property": {
-            "type": "ChemicalProperty",
-            "name": "Cesium",
-            "formula": "Cs",
-            "inchi": "InChI=1S/Cs",
-            "inchikey": "TVFDJXOCXUVLDH-UHFFFAOYSA-N"
-          },
-          "measurement": {
-            "value": "32.812",
-            "unitCode": "P1"
-          }
-        },
-        {
-          "type": "Observation",
-          "property": {
-            "type": "ChemicalProperty",
-            "name": "Antimony",
-            "formula": "Sb",
-            "inchi": "InChI=1S/Sb",
-            "inchikey": "WATWJIUSRGPENY-UHFFFAOYSA-N"
-          },
-          "measurement": {
-            "value": "40.179",
-            "unitCode": "P1"
-          }
-        },
-        {
-          "type": "Observation",
-          "property": {
-            "type": "ChemicalProperty",
-            "name": "Selenium",
-            "formula": "Se",
-            "inchi": "InChI=1S/Se",
-            "inchikey": "BUGBHKTXTAQXES-UHFFFAOYSA-N"
-          },
-          "measurement": {
-            "value": "3.3154",
-            "unitCode": "P1"
-          }
-        },
-        {
-          "type": "Observation",
-          "property": {
-            "type": "ChemicalProperty",
-            "name": "Nihonium",
-            "formula": "Nh"
-          },
-          "measurement": {
-            "value": "00.00",
-            "unitCode": "UNKNOWN"
-          }
-        },
-        {
-          "type": "Observation",
-          "property": {
-            "type": "ChemicalProperty",
-            "name": "Scandium",
-            "formula": "Sc",
-            "inchi": "InChI=1S/Sc",
-            "inchikey": "SIXSYDAISGFNSX-UHFFFAOYSA-N"
-          },
-          "measurement": {
-            "value": "23.694",
-            "unitCode": "P1"
-          }
-        }
-      ]
-    },
-    {
-      "@context": [
-        "https://w3id.org/traceability/v1"
-      ],
-      "type": "InspectionReport",
-      "observation": [
-        {
-          "type": "Observation",
-          "property": {
-            "type": "ChemicalProperty",
-            "name": "Indium",
-            "formula": "In",
-            "inchi": "InChI=1S/In",
-            "inchikey": "APFVFJFRJDLVQX-UHFFFAOYSA-N"
-          },
-          "measurement": {
-            "value": "33.267",
-            "unitCode": "P1"
           }
         },
         {
@@ -232,7 +29,7 @@
             "inchikey": "KLMCZVJOEAUDNE-UHFFFAOYSA-N"
           },
           "measurement": {
-            "value": "28.949",
+            "value": "100.00",
             "unitCode": "P1"
           }
         },
@@ -240,14 +37,12 @@
           "type": "Observation",
           "property": {
             "type": "ChemicalProperty",
-            "name": "Krypton",
-            "formula": "Kr",
-            "inchi": "InChI=1S/Kr",
-            "inchikey": "DNNSSWSSYDEUBZ-UHFFFAOYSA-N"
+            "name": "Seaborgium",
+            "formula": "Sg"
           },
           "measurement": {
-            "value": "37.783",
-            "unitCode": "P1"
+            "value": "00.00",
+            "unitCode": "UNKNOWN"
           }
         },
         {
@@ -259,7 +54,28 @@
             "description": "ISO 180 defines the method used for pendulums to determine the impact resistance of a plastic specimen when supported in a cantilever configuration. Test results are used to evaluate the resilience of materials, typically plastics."
           },
           "measurement": {
-            "value": "92.316",
+            "value": "50.487",
+            "unitCode": "B13"
+          }
+        }
+      ]
+    },
+    {
+      "@context": [
+        "https://w3id.org/traceability/v1"
+      ],
+      "type": "InspectionReport",
+      "observation": [
+        {
+          "type": "Observation",
+          "property": {
+            "type": "MechanicalProperty",
+            "identifier": "ISO 180",
+            "name": "Izod Impact Strength Test",
+            "description": "ISO 180 defines the method used for pendulums to determine the impact resistance of a plastic specimen when supported in a cantilever configuration. Test results are used to evaluate the resilience of materials, typically plastics."
+          },
+          "measurement": {
+            "value": "62.515",
             "unitCode": "B13"
           }
         },
@@ -267,13 +83,63 @@
           "type": "Observation",
           "property": {
             "type": "MechanicalProperty",
-            "identifier": "ISO 1352",
-            "name": "Torque-controlled fatigue testing",
-            "description": "ISO 1352:2011 specifies the conditions for performing torsional, constant-amplitude, nominally elastic stress fatigue tests on metallic specimens without deliberately introducing stress concentrations. The tests are carried out at ambient temperature (ideally at between 10 °C and 35 °C) in air by applying a pure couple to the specimen about its longitudinal axis."
+            "identifier": "ISO 148",
+            "name": "Charpy Impact Strength Test",
+            "description": "ISO 148-1:2016 specifies the Charpy (V-notch and U-notch) pendulum impact test method for determining the energy absorbed in an impact test of metallic materials. This part of ISO 148 does not cover instrumented impact testing, which is specified in ISO 14556."
           },
           "measurement": {
-            "value": "00.00",
-            "unitCode": "UNKNOWN"
+            "value": "96.659",
+            "unitCode": "B13"
+          }
+        },
+        {
+          "type": "Observation",
+          "property": {
+            "type": "ChemicalProperty",
+            "name": "Cobalt",
+            "formula": "Co",
+            "inchi": "InChI=1S/Co",
+            "inchikey": "GUTLYIVDDKVIGB-UHFFFAOYSA-N"
+          },
+          "measurement": {
+            "value": "100.00",
+            "unitCode": "P1"
+          }
+        }
+      ]
+    },
+    {
+      "@context": [
+        "https://w3id.org/traceability/v1"
+      ],
+      "type": "InspectionReport",
+      "observation": [
+        {
+          "type": "Observation",
+          "property": {
+            "type": "ChemicalProperty",
+            "name": "Xenon",
+            "formula": "Xe",
+            "inchi": "InChI=1S/Xe",
+            "inchikey": "FHNFHKCVQCLJFQ-UHFFFAOYSA-N"
+          },
+          "measurement": {
+            "value": "15.885",
+            "unitCode": "P1"
+          }
+        },
+        {
+          "type": "Observation",
+          "property": {
+            "type": "ChemicalProperty",
+            "name": "Gold",
+            "formula": "Au",
+            "inchi": "InChI=1S/Au",
+            "inchikey": "PCHJSUWPFVWCPO-UHFFFAOYSA-N"
+          },
+          "measurement": {
+            "value": "3.1246",
+            "unitCode": "P1"
           }
         },
         {
@@ -292,75 +158,24 @@
         {
           "type": "Observation",
           "property": {
+            "type": "ChemicalProperty",
+            "name": "Sodium",
+            "formula": "Na",
+            "inchi": "InChI=1S/Na",
+            "inchikey": "KEAYESYHFKHZAL-UHFFFAOYSA-N"
+          },
+          "measurement": {
+            "value": "28.043",
+            "unitCode": "P1"
+          }
+        },
+        {
+          "type": "Observation",
+          "property": {
             "type": "MechanicalProperty",
-            "identifier": "ISO 180",
-            "name": "Izod Impact Strength Test",
-            "description": "ISO 180 defines the method used for pendulums to determine the impact resistance of a plastic specimen when supported in a cantilever configuration. Test results are used to evaluate the resilience of materials, typically plastics."
-          },
-          "measurement": {
-            "value": "78.265",
-            "unitCode": "B13"
-          }
-        }
-      ]
-    }
-  ],
-  "bad": [
-    {
-      "program": "reboot",
-      "protocol": "connect"
-    },
-    {
-      "type": "InspectionReport",
-      "observation": [
-        {
-          "type": "Observation",
-          "property": {
-            "type": "ChemicalProperty",
-            "name": "Cesium",
-            "formula": "Cs",
-            "inchi": "InChI=1S/Cs",
-            "inchikey": "TVFDJXOCXUVLDH-UHFFFAOYSA-N"
-          },
-          "measurement": {
-            "value": "32.812",
-            "unitCode": "P1"
-          }
-        },
-        {
-          "type": "Observation",
-          "property": {
-            "type": "ChemicalProperty",
-            "name": "Antimony",
-            "formula": "Sb",
-            "inchi": "InChI=1S/Sb",
-            "inchikey": "WATWJIUSRGPENY-UHFFFAOYSA-N"
-          },
-          "measurement": {
-            "value": "40.179",
-            "unitCode": "P1"
-          }
-        },
-        {
-          "type": "Observation",
-          "property": {
-            "type": "ChemicalProperty",
-            "name": "Selenium",
-            "formula": "Se",
-            "inchi": "InChI=1S/Se",
-            "inchikey": "BUGBHKTXTAQXES-UHFFFAOYSA-N"
-          },
-          "measurement": {
-            "value": "3.3154",
-            "unitCode": "P1"
-          }
-        },
-        {
-          "type": "Observation",
-          "property": {
-            "type": "ChemicalProperty",
-            "name": "Nihonium",
-            "formula": "Nh"
+            "identifier": "ISO 3738",
+            "name": "Rockwell Hardness Test (Scale A)",
+            "description": "The Rockwell hardness test is an empirical indentation hardness test that can provide useful information about metallic materials."
           },
           "measurement": {
             "value": "00.00",
@@ -371,24 +186,70 @@
           "type": "Observation",
           "property": {
             "type": "ChemicalProperty",
-            "name": "Scandium",
-            "formula": "Sc",
-            "inchi": "InChI=1S/Sc",
-            "inchikey": "SIXSYDAISGFNSX-UHFFFAOYSA-N"
+            "name": "Aluminium",
+            "formula": "Al",
+            "inchi": "InChI=1S/Al",
+            "inchikey": "XAGFODPZIPBFFR-UHFFFAOYSA-N"
           },
           "measurement": {
-            "value": "23.694",
+            "value": "39.861",
             "unitCode": "P1"
           }
+        },
+        {
+          "type": "Observation",
+          "property": {
+            "type": "ChemicalProperty",
+            "name": "Radon",
+            "formula": "Rn",
+            "inchi": "InChI=1S/Rn",
+            "inchikey": "SYUHGPGVQRZVTB-UHFFFAOYSA-N"
+          },
+          "measurement": {
+            "value": "13.087",
+            "unitCode": "P1"
+          }
+        },
+        {
+          "type": "Observation",
+          "property": {
+            "type": "MechanicalProperty",
+            "identifier": "ISO 1352",
+            "name": "Torque-controlled fatigue testing",
+            "description": "ISO 1352:2011 specifies the conditions for performing torsional, constant-amplitude, nominally elastic stress fatigue tests on metallic specimens without deliberately introducing stress concentrations. The tests are carried out at ambient temperature (ideally at between 10 °C and 35 °C) in air by applying a pure couple to the specimen about its longitudinal axis."
+          },
+          "measurement": {
+            "value": "00.00",
+            "unitCode": "UNKNOWN"
+          }
         }
+      ]
+    }
+  ],
+  "bad": [
+    {
+      "@context": [
+        "https://w3id.org/traceability/v1"
       ],
-      "hard drive": "generate",
-      "bus": "transmit",
-      "bandwidth": "compress"
+      "sensor": "generate"
     },
     {
-      "driver": "hack",
-      "panel": "quantify"
+      "@context": [
+        "https://w3id.org/traceability/v1"
+      ],
+      "pixel": "parse",
+      "array": "back up",
+      "bandwidth": "hack",
+      "protocol": "input"
+    },
+    {
+      "@context": [
+        "https://w3id.org/traceability/v1"
+      ],
+      "type": "InspectionReport",
+      "interface": "program",
+      "port": "index",
+      "monitor": "back up"
     }
   ]
 }

--- a/docs/test-vectors/Inspector.json
+++ b/docs/test-vectors/Inspector.json
@@ -5,17 +5,34 @@
         "https://w3id.org/traceability/v1"
       ],
       "type": "Inspector",
-      "person": "Julius Hartmann",
+      "person": {
+        "type": "Person",
+        "firstName": "Evie",
+        "lastName": "Kuhic",
+        "email": "Minnie29@yahoo.com",
+        "phoneNumber": "(377) 777-0267 x195",
+        "worksFor": {
+          "type": "Organization",
+          "name": "Hane - Lang",
+          "description": "Programmable directional software",
+          "address": {
+            "type": "PostalAddress",
+            "streetAddress": "9567 Wunsch Square",
+            "addressLocality": "North Jade",
+            "addressRegion": "Alaska",
+            "postalCode": "74640",
+            "addressCountry": "Grenada"
+          },
+          "email": "Koby58@gmail.com",
+          "phoneNumber": "377-887-6127 x3853"
+        },
+        "jobTitle": "Dynamic Response Technician"
+      },
       "credential": [
         {
           "type": "Credential",
-          "credentialCategory": "Corporate Research Designer",
-          "credentialValue": "Architect"
-        },
-        {
-          "type": "Credential",
-          "credentialCategory": "International Security Producer",
-          "credentialValue": "Producer"
+          "credentialCategory": "Global Identity Administrator",
+          "credentialValue": "Agent"
         }
       ]
     },
@@ -24,22 +41,34 @@
         "https://w3id.org/traceability/v1"
       ],
       "type": "Inspector",
-      "person": "Sheryl Heidenreich",
+      "person": {
+        "type": "Person",
+        "firstName": "Horace",
+        "lastName": "Bashirian",
+        "email": "Carlee89@gmail.com",
+        "phoneNumber": "227.753.9606 x7274",
+        "worksFor": {
+          "type": "Organization",
+          "name": "Casper - Hintz",
+          "description": "Grass-roots next generation info-mediaries",
+          "address": {
+            "type": "PostalAddress",
+            "streetAddress": "51258 Kub Courts",
+            "addressLocality": "Port Lilianabury",
+            "addressRegion": "Wyoming",
+            "postalCode": "38565",
+            "addressCountry": "Namibia"
+          },
+          "email": "Gaylord26@yahoo.com",
+          "phoneNumber": "911-751-7313"
+        },
+        "jobTitle": "Corporate Quality Designer"
+      },
       "credential": [
         {
           "type": "Credential",
-          "credentialCategory": "Direct Group Analyst",
-          "credentialValue": "Liaison"
-        },
-        {
-          "type": "Credential",
-          "credentialCategory": "Chief Communications Coordinator",
-          "credentialValue": "Strategist"
-        },
-        {
-          "type": "Credential",
-          "credentialCategory": "Corporate Paradigm Assistant",
-          "credentialValue": "Planner"
+          "credentialCategory": "Legacy Mobility Designer",
+          "credentialValue": "Coordinator"
         }
       ]
     },
@@ -48,78 +77,62 @@
         "https://w3id.org/traceability/v1"
       ],
       "type": "Inspector",
-      "person": "Erin Considine III",
+      "person": {
+        "type": "Person",
+        "firstName": "Hester",
+        "lastName": "Bahringer",
+        "email": "Bria_Mante1@gmail.com",
+        "phoneNumber": "(593) 911-0654 x485",
+        "worksFor": {
+          "type": "Organization",
+          "name": "Hamill LLC",
+          "description": "Persevering content-based implementation",
+          "address": {
+            "type": "PostalAddress",
+            "streetAddress": "601 Hirthe Circles",
+            "addressLocality": "Friesenport",
+            "addressRegion": "Montana",
+            "postalCode": "10655-8812",
+            "addressCountry": "Paraguay"
+          },
+          "email": "Loma_Carroll85@yahoo.com",
+          "phoneNumber": "593-975-7547 x26115"
+        },
+        "jobTitle": "Chief Identity Assistant"
+      },
       "credential": [
         {
           "type": "Credential",
-          "credentialCategory": "Dynamic Functionality Manager",
-          "credentialValue": "Strategist"
+          "credentialCategory": "Human Optimization Officer",
+          "credentialValue": "Assistant"
         },
         {
           "type": "Credential",
-          "credentialCategory": "Corporate Research Producer",
-          "credentialValue": "Analyst"
+          "credentialCategory": "Regional Functionality Agent",
+          "credentialValue": "Executive"
+        },
+        {
+          "type": "Credential",
+          "credentialCategory": "District Group Administrator",
+          "credentialValue": "Coordinator"
         }
       ]
     }
   ],
   "bad": [
     {
-      "type": "Inspector",
-      "credential": [
-        {
-          "type": "Credential",
-          "credentialCategory": "Corporate Research Designer",
-          "credentialValue": "Architect"
-        },
-        {
-          "type": "Credential",
-          "credentialCategory": "International Security Producer",
-          "credentialValue": "Producer"
-        }
-      ],
-      "microchip": "generate"
+      "array": "override",
+      "panel": "generate",
+      "system": "synthesize"
     },
     {
       "@context": [
         "https://w3id.org/traceability/v1"
       ],
-      "person": "Sheryl Heidenreich",
-      "credential": [
-        {
-          "type": "Credential",
-          "credentialCategory": "Direct Group Analyst",
-          "credentialValue": "Liaison"
-        },
-        {
-          "type": "Credential",
-          "credentialCategory": "Chief Communications Coordinator",
-          "credentialValue": "Strategist"
-        },
-        {
-          "type": "Credential",
-          "credentialCategory": "Corporate Paradigm Assistant",
-          "credentialValue": "Planner"
-        }
-      ],
-      "feed": "connect",
-      "sensor": "navigate"
+      "panel": "reboot"
     },
     {
-      "person": "Erin Considine III",
-      "credential": [
-        {
-          "type": "Credential",
-          "credentialCategory": "Dynamic Functionality Manager",
-          "credentialValue": "Strategist"
-        },
-        {
-          "type": "Credential",
-          "credentialCategory": "Corporate Research Producer",
-          "credentialValue": "Analyst"
-        }
-      ],
-      "monitor": "override"
+      "feed": "navigate"
     }
   ]
 }

--- a/docs/test-vectors/Observation.json
+++ b/docs/test-vectors/Observation.json
@@ -6,14 +6,30 @@
       ],
       "type": "Observation",
       "property": {
-        "type": "ChemicalProperty",
-        "name": "Titanium",
-        "formula": "Ti",
-        "inchi": "InChI=1S/Ti",
-        "inchikey": "RTAQQCXQSZGOHL-UHFFFAOYSA-N"
+        "type": "MechanicalProperty",
+        "identifier": "ISO 180",
+        "name": "Izod Impact Strength Test",
+        "description": "ISO 180 defines the method used for pendulums to determine the impact resistance of a plastic specimen when supported in a cantilever configuration. Test results are used to evaluate the resilience of materials, typically plastics."
       },
       "measurement": {
-        "value": "36.424",
+        "value": "39.819",
+        "unitCode": "B13"
+      }
+    },
+    {
+      "@context": [
+        "https://w3id.org/traceability/v1"
+      ],
+      "type": "Observation",
+      "property": {
+        "type": "ChemicalProperty",
+        "name": "Copper",
+        "formula": "Cu",
+        "inchi": "InChI=1S/Cu",
+        "inchikey": "RYGMFSIKBFXOCR-UHFFFAOYSA-N"
+      },
+      "measurement": {
+        "value": "86.107",
         "unitCode": "P1"
       }
     },
@@ -24,54 +40,49 @@
       "type": "Observation",
       "property": {
         "type": "ChemicalProperty",
-        "name": "Cadmium",
-        "formula": "Cd",
-        "inchi": "InChI=1S/Cd",
-        "inchikey": "BDOSMKKIYDKNTQ-UHFFFAOYSA-N"
+        "name": "Chromium",
+        "formula": "Cr",
+        "inchi": "InChI=1S/Cr",
+        "inchikey": "VYZAMTAEIAYCRO-UHFFFAOYSA-N"
       },
       "measurement": {
-        "value": "8.747",
-        "unitCode": "P1"
-      }
-    },
-    {
-      "@context": [
-        "https://w3id.org/traceability/v1"
-      ],
-      "type": "Observation",
-      "property": {
-        "type": "ChemicalProperty",
-        "name": "Lanthanum",
-        "formula": "La",
-        "inchi": "InChI=1S/La",
-        "inchikey": "FZLIPJUXYLNCLC-UHFFFAOYSA-N"
-      },
-      "measurement": {
-        "value": "67.285",
+        "value": "83.190",
         "unitCode": "P1"
       }
     }
   ],
   "bad": [
     {
-      "hard drive": "synthesize",
-      "application": "transmit",
-      "microchip": "parse",
-      "system": "hack"
+      "program": "back up",
+      "circuit": "copy",
+      "microchip": "index",
+      "transmitter": "compress"
     },
     {
-      "@context": [
-        "https://w3id.org/traceability/v1"
-      ],
+      "property": {
+        "type": "ChemicalProperty",
+        "name": "Copper",
+        "formula": "Cu",
+        "inchi": "InChI=1S/Cu",
+        "inchikey": "RYGMFSIKBFXOCR-UHFFFAOYSA-N"
+      },
+      "alarm": "override",
+      "array": "synthesize",
+      "driver": "reboot"
+    },
+    {
+      "property": {
+        "type": "ChemicalProperty",
+        "name": "Chromium",
+        "formula": "Cr",
+        "inchi": "InChI=1S/Cr",
+        "inchikey": "VYZAMTAEIAYCRO-UHFFFAOYSA-N"
+      },
       "measurement": {
-        "value": "8.747",
+        "value": "83.190",
         "unitCode": "P1"
       },
-      "array": "generate"
-    },
-    {
-      "pixel": "hack",
-      "application": "program"
+      "matrix": "calculate"
     }
   ]
 }

--- a/docs/test-vectors/Organization.json
+++ b/docs/test-vectors/Organization.json
@@ -1,0 +1,80 @@
+{
+  "good": [
+    {
+      "@context": [
+        "https://w3id.org/traceability/v1"
+      ],
+      "type": "Organization",
+      "name": "Haley LLC",
+      "description": "Vision-oriented mission-critical local area network",
+      "address": {
+        "type": "PostalAddress",
+        "streetAddress": "4774 Hessel Viaduct",
+        "addressLocality": "Koelpinland",
+        "addressRegion": "West Virginia",
+        "postalCode": "10929-2431",
+        "addressCountry": "Gibraltar"
+      },
+      "email": "Garnet.Padberg@hotmail.com",
+      "phoneNumber": "1-574-531-2090 x69016"
+    },
+    {
+      "@context": [
+        "https://w3id.org/traceability/v1"
+      ],
+      "type": "Organization",
+      "name": "Mitchell, Hackett and McGlynn",
+      "description": "Focused systemic software",
+      "address": {
+        "type": "PostalAddress",
+        "streetAddress": "56339 Labadie Brooks",
+        "addressLocality": "Lake Guadalupestad",
+        "addressRegion": "Nevada",
+        "postalCode": "50842",
+        "addressCountry": "Antarctica (the territory South of 60 deg S)"
+      },
+      "email": "Brody.Stanton68@yahoo.com",
+      "phoneNumber": "612.369.8465 x805"
+    },
+    {
+      "@context": [
+        "https://w3id.org/traceability/v1"
+      ],
+      "type": "Organization",
+      "name": "Haley LLC",
+      "description": "Total leading edge conglomeration",
+      "address": {
+        "type": "PostalAddress",
+        "streetAddress": "907 Mohammad Garden",
+        "addressLocality": "North Ricky",
+        "addressRegion": "Oklahoma",
+        "postalCode": "04127-9990",
+        "addressCountry": "Maldives"
+      },
+      "email": "Lavon_Swift@hotmail.com",
+      "phoneNumber": "(748) 987-7129 x5637"
+    }
+  ],
+  "bad": [
+    {
+      "type": "Organization",
+      "transmitter": "override",
+      "capacitor": "calculate",
+      "monitor": "override"
+    },
+    {
+      "matrix": "copy",
+      "bus": "back up",
+      "microchip": "parse",
+      "sensor": "generate"
+    },
+    {
+      "type": "Organization",
+      "description": "Total leading edge conglomeration",
+      "microchip": "navigate",
+      "firewall": "quantify",
+      "port": "hack",
+      "card": "back up"
+    }
+  ]
+}

--- a/docs/test-vectors/ParcelDelivery.json
+++ b/docs/test-vectors/ParcelDelivery.json
@@ -1,0 +1,467 @@
+{
+  "good": [
+    {
+      "@context": [
+        "https://w3id.org/traceability/v1"
+      ],
+      "type": "ParcelDelivery",
+      "deliveryAddress": {
+        "type": "PostalAddress",
+        "organizationName": "Veum - O'Kon",
+        "streetAddress": "95908 Corwin Vista",
+        "addressLocality": "Lake Jayde",
+        "addressRegion": "Maryland",
+        "postalCode": "45737-5267",
+        "addressCountry": "Virgin Islands, U.S."
+      },
+      "originAddress": {
+        "type": "PostalAddress",
+        "organizationName": "Mraz, Keeling and Huels",
+        "streetAddress": "92784 Rice Roads",
+        "addressLocality": "Keeblershire",
+        "addressRegion": "Wyoming",
+        "postalCode": "28932",
+        "addressCountry": "Hungary"
+      },
+      "trackingNumber": "401546314975",
+      "products": [
+        {
+          "type": "Product",
+          "manufacturer": {
+            "type": "Person",
+            "firstName": "Keith",
+            "lastName": "Skiles",
+            "email": "Jon.Stiedemann41@yahoo.com",
+            "phoneNumber": "1-787-298-3130 x3469",
+            "worksFor": {
+              "type": "Organization",
+              "name": "King, Miller and Legros",
+              "description": "Right-sized tertiary definition",
+              "address": {
+                "type": "PostalAddress",
+                "streetAddress": "25205 Stokes Squares",
+                "addressLocality": "West Rae",
+                "addressRegion": "Delaware",
+                "postalCode": "29172",
+                "addressCountry": "Bouvet Island (Bouvetoya)"
+              },
+              "email": "Derick90@hotmail.com",
+              "phoneNumber": "715.690.4367 x8288"
+            },
+            "jobTitle": "Internal Usability Administrator"
+          },
+          "name": "Gorgeous Soft Tuna",
+          "description": "Ergonomic executive chair upholstered in bonded black leather and PVC padded seat and back for all-day comfort and support",
+          "sizeOrAmount": {
+            "type": "QuantitativeValue",
+            "unitCode": "hg/ha",
+            "value": "566"
+          },
+          "weight": {
+            "type": "QuantitativeValue",
+            "unitCode": "hg/ha",
+            "value": "7222"
+          },
+          "sku": "165788693926"
+        },
+        {
+          "type": "Product",
+          "manufacturer": {
+            "type": "Organization",
+            "name": "Keeling, Watsica and Lindgren",
+            "description": "Seamless intangible secured line",
+            "address": {
+              "type": "PostalAddress",
+              "streetAddress": "80724 Stephanie Points",
+              "addressLocality": "New Joesphburgh",
+              "addressRegion": "New Jersey",
+              "postalCode": "02802",
+              "addressCountry": "Cote d'Ivoire"
+            },
+            "email": "Ellen37@gmail.com",
+            "phoneNumber": "537.948.1856"
+          },
+          "name": "Gorgeous Fresh Chips",
+          "description": "Andy shoes are designed to keeping in mind durability as well as trends, the most stylish range of shoes & sandals",
+          "sizeOrAmount": {
+            "type": "QuantitativeValue",
+            "unitCode": "hg/ha",
+            "value": "7981"
+          },
+          "weight": {
+            "type": "QuantitativeValue",
+            "unitCode": "hg/ha",
+            "value": "4651"
+          },
+          "sku": "801948730210"
+        },
+        {
+          "type": "Product",
+          "manufacturer": {
+            "type": "Person",
+            "firstName": "Hunter",
+            "lastName": "Torphy",
+            "email": "Faye19@hotmail.com",
+            "phoneNumber": "830.908.0086 x33230",
+            "worksFor": {
+              "type": "Organization",
+              "name": "Dibbert - Rohan",
+              "description": "Future-proofed asymmetric ability",
+              "address": {
+                "type": "PostalAddress",
+                "streetAddress": "664 Welch Mountain",
+                "addressLocality": "Hettingerton",
+                "addressRegion": "Connecticut",
+                "postalCode": "04805-8213",
+                "addressCountry": "Cote d'Ivoire"
+              },
+              "email": "Brayan_Mitchell@yahoo.com",
+              "phoneNumber": "331-973-3810"
+            },
+            "jobTitle": "District Functionality Coordinator"
+          },
+          "name": "Ergonomic Metal Cheese",
+          "description": "The slim & simple Maple Gaming Keyboard from Dev Byte comes with a sleek body and 7- Color RGB LED Back-lighting for smart functionality",
+          "sizeOrAmount": {
+            "type": "QuantitativeValue",
+            "unitCode": "hg/ha",
+            "value": "6182"
+          },
+          "weight": {
+            "type": "QuantitativeValue",
+            "unitCode": "hg/ha",
+            "value": "3624"
+          },
+          "sku": "516906568294"
+        }
+      ]
+    },
+    {
+      "@context": [
+        "https://w3id.org/traceability/v1"
+      ],
+      "type": "ParcelDelivery",
+      "deliveryAddress": {
+        "type": "PostalAddress",
+        "organizationName": "Hickle, Green and Gulgowski",
+        "streetAddress": "6608 Lindgren Cliffs",
+        "addressLocality": "Hagenesfurt",
+        "addressRegion": "North Dakota",
+        "postalCode": "23678-7332",
+        "addressCountry": "Bermuda"
+      },
+      "originAddress": {
+        "type": "PostalAddress",
+        "organizationName": "Bogisich, Collins and Murazik",
+        "streetAddress": "1952 Noble Ville",
+        "addressLocality": "South Roel",
+        "addressRegion": "Ohio",
+        "postalCode": "40883-1681",
+        "addressCountry": "Hungary"
+      },
+      "trackingNumber": "226798274110",
+      "products": [
+        {
+          "type": "Product",
+          "manufacturer": {
+            "type": "Person",
+            "firstName": "Diego",
+            "lastName": "Kub",
+            "email": "Kory.Osinski91@yahoo.com",
+            "phoneNumber": "204-936-1185 x605",
+            "worksFor": {
+              "type": "Organization",
+              "name": "Bogisich, Bode and Grimes",
+              "description": "Public-key user-facing middleware",
+              "address": {
+                "type": "PostalAddress",
+                "streetAddress": "2686 Harber Forks",
+                "addressLocality": "Luettgenchester",
+                "addressRegion": "New Mexico",
+                "postalCode": "42755-7680",
+                "addressCountry": "Saint Lucia"
+              },
+              "email": "Deshawn.Reinger85@yahoo.com",
+              "phoneNumber": "579-442-4262"
+            },
+            "jobTitle": "District Markets Assistant"
+          },
+          "name": "Rustic Metal Mouse",
+          "description": "Andy shoes are designed to keeping in mind durability as well as trends, the most stylish range of shoes & sandals",
+          "sizeOrAmount": {
+            "type": "QuantitativeValue",
+            "unitCode": "hg/ha",
+            "value": "6470"
+          },
+          "weight": {
+            "type": "QuantitativeValue",
+            "unitCode": "hg/ha",
+            "value": "3983"
+          },
+          "sku": "128267951770"
+        }
+      ]
+    },
+    {
+      "@context": [
+        "https://w3id.org/traceability/v1"
+      ],
+      "type": "ParcelDelivery",
+      "deliveryAddress": {
+        "type": "PostalAddress",
+        "organizationName": "White Inc",
+        "streetAddress": "9784 Leffler Dam",
+        "addressLocality": "New Diego",
+        "addressRegion": "Oregon",
+        "postalCode": "47183-5990",
+        "addressCountry": "Tokelau"
+      },
+      "originAddress": {
+        "type": "PostalAddress",
+        "organizationName": "Koepp LLC",
+        "streetAddress": "7244 Kunde Glens",
+        "addressLocality": "Wayneborough",
+        "addressRegion": "Louisiana",
+        "postalCode": "73186",
+        "addressCountry": "Faroe Islands"
+      },
+      "trackingNumber": "210537393926",
+      "products": [
+        {
+          "type": "Product",
+          "manufacturer": {
+            "type": "Organization",
+            "name": "Connelly, Corwin and Rath",
+            "description": "Versatile homogeneous time-frame",
+            "address": {
+              "type": "PostalAddress",
+              "streetAddress": "37752 Diana Land",
+              "addressLocality": "Bergnaummouth",
+              "addressRegion": "Alaska",
+              "postalCode": "80687-0610",
+              "addressCountry": "Kuwait"
+            },
+            "email": "Vincenza.Borer@gmail.com",
+            "phoneNumber": "701-997-6375 x4126"
+          },
+          "name": "Unbranded Steel Ball",
+          "description": "The automobile layout consists of a front-engine design, with transaxle-type transmissions mounted at the rear of the engine and four wheel drive",
+          "sizeOrAmount": {
+            "type": "QuantitativeValue",
+            "unitCode": "hg/ha",
+            "value": "9891"
+          },
+          "weight": {
+            "type": "QuantitativeValue",
+            "unitCode": "hg/ha",
+            "value": "2739"
+          },
+          "sku": "405649282369"
+        },
+        {
+          "type": "Product",
+          "manufacturer": {
+            "type": "Person",
+            "firstName": "Junior",
+            "lastName": "Stoltenberg",
+            "email": "Arvel.Stehr@hotmail.com",
+            "phoneNumber": "497-729-3522",
+            "worksFor": {
+              "type": "Organization",
+              "name": "Hayes - Schaden",
+              "description": "Operative needs-based knowledge user",
+              "address": {
+                "type": "PostalAddress",
+                "streetAddress": "24041 Liliana Rapid",
+                "addressLocality": "New Dewayne",
+                "addressRegion": "Montana",
+                "postalCode": "59084-5273",
+                "addressCountry": "Russian Federation"
+              },
+              "email": "Frederic_Stroman39@gmail.com",
+              "phoneNumber": "567.945.4808"
+            },
+            "jobTitle": "Dynamic Research Orchestrator"
+          },
+          "name": "Handcrafted Plastic Chips",
+          "description": "Ergonomic executive chair upholstered in bonded black leather and PVC padded seat and back for all-day comfort and support",
+          "sizeOrAmount": {
+            "type": "QuantitativeValue",
+            "unitCode": "hg/ha",
+            "value": "8212"
+          },
+          "weight": {
+            "type": "QuantitativeValue",
+            "unitCode": "hg/ha",
+            "value": "3592"
+          },
+          "sku": "105269685098"
+        }
+      ]
+    }
+  ],
+  "bad": [
+    {
+      "type": "ParcelDelivery",
+      "deliveryAddress": {
+        "type": "PostalAddress",
+        "organizationName": "Veum - O'Kon",
+        "streetAddress": "95908 Corwin Vista",
+        "addressLocality": "Lake Jayde",
+        "addressRegion": "Maryland",
+        "postalCode": "45737-5267",
+        "addressCountry": "Virgin Islands, U.S."
+      },
+      "originAddress": {
+        "type": "PostalAddress",
+        "organizationName": "Mraz, Keeling and Huels",
+        "streetAddress": "92784 Rice Roads",
+        "addressLocality": "Keeblershire",
+        "addressRegion": "Wyoming",
+        "postalCode": "28932",
+        "addressCountry": "Hungary"
+      },
+      "trackingNumber": "401546314975",
+      "products": [
+        {
+          "type": "Product",
+          "manufacturer": {
+            "type": "Person",
+            "firstName": "Keith",
+            "lastName": "Skiles",
+            "email": "Jon.Stiedemann41@yahoo.com",
+            "phoneNumber": "1-787-298-3130 x3469",
+            "worksFor": {
+              "type": "Organization",
+              "name": "King, Miller and Legros",
+              "description": "Right-sized tertiary definition",
+              "address": {
+                "type": "PostalAddress",
+                "streetAddress": "25205 Stokes Squares",
+                "addressLocality": "West Rae",
+                "addressRegion": "Delaware",
+                "postalCode": "29172",
+                "addressCountry": "Bouvet Island (Bouvetoya)"
+              },
+              "email": "Derick90@hotmail.com",
+              "phoneNumber": "715.690.4367 x8288"
+            },
+            "jobTitle": "Internal Usability Administrator"
+          },
+          "name": "Gorgeous Soft Tuna",
+          "description": "Ergonomic executive chair upholstered in bonded black leather and PVC padded seat and back for all-day comfort and support",
+          "sizeOrAmount": {
+            "type": "QuantitativeValue",
+            "unitCode": "hg/ha",
+            "value": "566"
+          },
+          "weight": {
+            "type": "QuantitativeValue",
+            "unitCode": "hg/ha",
+            "value": "7222"
+          },
+          "sku": "165788693926"
+        },
+        {
+          "type": "Product",
+          "manufacturer": {
+            "type": "Organization",
+            "name": "Keeling, Watsica and Lindgren",
+            "description": "Seamless intangible secured line",
+            "address": {
+              "type": "PostalAddress",
+              "streetAddress": "80724 Stephanie Points",
+              "addressLocality": "New Joesphburgh",
+              "addressRegion": "New Jersey",
+              "postalCode": "02802",
+              "addressCountry": "Cote d'Ivoire"
+            },
+            "email": "Ellen37@gmail.com",
+            "phoneNumber": "537.948.1856"
+          },
+          "name": "Gorgeous Fresh Chips",
+          "description": "Andy shoes are designed to keeping in mind durability as well as trends, the most stylish range of shoes & sandals",
+          "sizeOrAmount": {
+            "type": "QuantitativeValue",
+            "unitCode": "hg/ha",
+            "value": "7981"
+          },
+          "weight": {
+            "type": "QuantitativeValue",
+            "unitCode": "hg/ha",
+            "value": "4651"
+          },
+          "sku": "801948730210"
+        },
+        {
+          "type": "Product",
+          "manufacturer": {
+            "type": "Person",
+            "firstName": "Hunter",
+            "lastName": "Torphy",
+            "email": "Faye19@hotmail.com",
+            "phoneNumber": "830.908.0086 x33230",
+            "worksFor": {
+              "type": "Organization",
+              "name": "Dibbert - Rohan",
+              "description": "Future-proofed asymmetric ability",
+              "address": {
+                "type": "PostalAddress",
+                "streetAddress": "664 Welch Mountain",
+                "addressLocality": "Hettingerton",
+                "addressRegion": "Connecticut",
+                "postalCode": "04805-8213",
+                "addressCountry": "Cote d'Ivoire"
+              },
+              "email": "Brayan_Mitchell@yahoo.com",
+              "phoneNumber": "331-973-3810"
+            },
+            "jobTitle": "District Functionality Coordinator"
+          },
+          "name": "Ergonomic Metal Cheese",
+          "description": "The slim & simple Maple Gaming Keyboard from Dev Byte comes with a sleek body and 7- Color RGB LED Back-lighting for smart functionality",
+          "sizeOrAmount": {
+            "type": "QuantitativeValue",
+            "unitCode": "hg/ha",
+            "value": "6182"
+          },
+          "weight": {
+            "type": "QuantitativeValue",
+            "unitCode": "hg/ha",
+            "value": "3624"
+          },
+          "sku": "516906568294"
+        }
+      ],
+      "bus": "navigate"
+    },
+    {
+      "interface": "connect"
+    },
+    {
+      "@context": [
+        "https://w3id.org/traceability/v1"
+      ],
+      "deliveryAddress": {
+        "type": "PostalAddress",
+        "organizationName": "White Inc",
+        "streetAddress": "9784 Leffler Dam",
+        "addressLocality": "New Diego",
+        "addressRegion": "Oregon",
+        "postalCode": "47183-5990",
+        "addressCountry": "Tokelau"
+      },
+      "originAddress": {
+        "type": "PostalAddress",
+        "organizationName": "Koepp LLC",
+        "streetAddress": "7244 Kunde Glens",
+        "addressLocality": "Wayneborough",
+        "addressRegion": "Louisiana",
+        "postalCode": "73186",
+        "addressCountry": "Faroe Islands"
+      },
+      "alarm": "synthesize",
+      "circuit": "generate"
+    }
+  ]
+}

--- a/docs/test-vectors/Person.json
+++ b/docs/test-vectors/Person.json
@@ -1,0 +1,143 @@
+{
+  "good": [
+    {
+      "@context": [
+        "https://w3id.org/traceability/v1"
+      ],
+      "type": "Person",
+      "firstName": "Reggie",
+      "lastName": "Swaniawski",
+      "email": "Abbigail_Wintheiser96@yahoo.com",
+      "phoneNumber": "1-669-877-4103",
+      "worksFor": {
+        "type": "Organization",
+        "name": "Rath, Fadel and Von",
+        "description": "Compatible responsive knowledge base",
+        "address": {
+          "type": "PostalAddress",
+          "streetAddress": "49334 Weissnat Curve",
+          "addressLocality": "East Lisandroside",
+          "addressRegion": "South Dakota",
+          "postalCode": "04081",
+          "addressCountry": "Swaziland"
+        },
+        "email": "Isobel_Kihn@hotmail.com",
+        "phoneNumber": "1-941-975-4053 x0265"
+      },
+      "jobTitle": "District Accountability Officer"
+    },
+    {
+      "@context": [
+        "https://w3id.org/traceability/v1"
+      ],
+      "type": "Person",
+      "firstName": "Layla",
+      "lastName": "Wisozk",
+      "email": "Magdalena.Orn@gmail.com",
+      "phoneNumber": "379-636-0905 x53569",
+      "worksFor": {
+        "type": "Organization",
+        "name": "Toy LLC",
+        "description": "Total background initiative",
+        "address": {
+          "type": "PostalAddress",
+          "streetAddress": "304 Jaskolski Spur",
+          "addressLocality": "Kilbacktown",
+          "addressRegion": "Louisiana",
+          "postalCode": "31843-1657",
+          "addressCountry": "Cote d'Ivoire"
+        },
+        "email": "Braden_Kilback18@hotmail.com",
+        "phoneNumber": "1-777-789-8569"
+      },
+      "jobTitle": "Investor Infrastructure Specialist"
+    },
+    {
+      "@context": [
+        "https://w3id.org/traceability/v1"
+      ],
+      "type": "Person",
+      "firstName": "Elliot",
+      "lastName": "Halvorson",
+      "email": "Richard72@hotmail.com",
+      "phoneNumber": "724.861.5735",
+      "worksFor": {
+        "type": "Organization",
+        "name": "Balistreri, Ankunding and Dach",
+        "description": "Persistent asymmetric concept",
+        "address": {
+          "type": "PostalAddress",
+          "streetAddress": "0406 Walter Flats",
+          "addressLocality": "Destiniberg",
+          "addressRegion": "Delaware",
+          "postalCode": "55182",
+          "addressCountry": "South Georgia and the South Sandwich Islands"
+        },
+        "email": "Damaris.Stracke@hotmail.com",
+        "phoneNumber": "291.512.5551"
+      },
+      "jobTitle": "Lead Division Agent"
+    }
+  ],
+  "bad": [
+    {
+      "pixel": "generate"
+    },
+    {
+      "@context": [
+        "https://w3id.org/traceability/v1"
+      ],
+      "type": "Person",
+      "firstName": "Layla",
+      "lastName": "Wisozk",
+      "email": "Magdalena.Orn@gmail.com",
+      "phoneNumber": "379-636-0905 x53569",
+      "worksFor": {
+        "type": "Organization",
+        "name": "Toy LLC",
+        "description": "Total background initiative",
+        "address": {
+          "type": "PostalAddress",
+          "streetAddress": "304 Jaskolski Spur",
+          "addressLocality": "Kilbacktown",
+          "addressRegion": "Louisiana",
+          "postalCode": "31843-1657",
+          "addressCountry": "Cote d'Ivoire"
+        },
+        "email": "Braden_Kilback18@hotmail.com",
+        "phoneNumber": "1-777-789-8569"
+      },
+      "microchip": "generate",
+      "sensor": "generate",
+      "alarm": "transmit",
+      "transmitter": "override"
+    },
+    {
+      "type": "Person",
+      "firstName": "Elliot",
+      "lastName": "Halvorson",
+      "email": "Richard72@hotmail.com",
+      "phoneNumber": "724.861.5735",
+      "worksFor": {
+        "type": "Organization",
+        "name": "Balistreri, Ankunding and Dach",
+        "description": "Persistent asymmetric concept",
+        "address": {
+          "type": "PostalAddress",
+          "streetAddress": "0406 Walter Flats",
+          "addressLocality": "Destiniberg",
+          "addressRegion": "Delaware",
+          "postalCode": "55182",
+          "addressCountry": "South Georgia and the South Sandwich Islands"
+        },
+        "email": "Damaris.Stracke@hotmail.com",
+        "phoneNumber": "291.512.5551"
+      },
+      "jobTitle": "Lead Division Agent",
+      "matrix": "navigate",
+      "transmitter": "reboot",
+      "hard drive": "program",
+      "microchip": "transmit"
+    }
+  ]
+}

--- a/docs/test-vectors/Product.json
+++ b/docs/test-vectors/Product.json
@@ -1,0 +1,206 @@
+{
+  "good": [
+    {
+      "@context": [
+        "https://w3id.org/traceability/v1"
+      ],
+      "type": "Product",
+      "manufacturer": {
+        "type": "Person",
+        "firstName": "Jerrod",
+        "lastName": "Bogan",
+        "email": "Odessa39@gmail.com",
+        "phoneNumber": "(574) 269-8462 x579",
+        "worksFor": {
+          "type": "Organization",
+          "name": "Emmerich, Mante and Donnelly",
+          "description": "Implemented disintermediate groupware",
+          "address": {
+            "type": "PostalAddress",
+            "streetAddress": "45308 Jaycee Vista",
+            "addressLocality": "Eusebiofort",
+            "addressRegion": "South Dakota",
+            "postalCode": "30949-9264",
+            "addressCountry": "Estonia"
+          },
+          "email": "Claude_Kihn26@yahoo.com",
+          "phoneNumber": "683-380-4851"
+        },
+        "jobTitle": "Corporate Data Orchestrator"
+      },
+      "name": "Sleek Frozen Mouse",
+      "description": "The Nagasaki Lander is the trademarked name of several series of Nagasaki sport bikes, that started with the 1984 ABC800J",
+      "sizeOrAmount": {
+        "type": "QuantitativeValue",
+        "unitCode": "hg/ha",
+        "value": "5912"
+      },
+      "weight": {
+        "type": "QuantitativeValue",
+        "unitCode": "hg/ha",
+        "value": "8206"
+      },
+      "sku": "43632142035"
+    },
+    {
+      "@context": [
+        "https://w3id.org/traceability/v1"
+      ],
+      "type": "Product",
+      "manufacturer": {
+        "type": "Person",
+        "firstName": "Yazmin",
+        "lastName": "Abernathy",
+        "email": "Sven.Schmeler@yahoo.com",
+        "phoneNumber": "(488) 716-9876 x18990",
+        "worksFor": {
+          "type": "Organization",
+          "name": "Dietrich - Reichel",
+          "description": "Reduced web-enabled extranet",
+          "address": {
+            "type": "PostalAddress",
+            "streetAddress": "3646 Aurelie Point",
+            "addressLocality": "Tessieberg",
+            "addressRegion": "Oregon",
+            "postalCode": "28003-5169",
+            "addressCountry": "Sao Tome and Principe"
+          },
+          "email": "Gideon4@yahoo.com",
+          "phoneNumber": "870.993.9296"
+        },
+        "jobTitle": "National Brand Director"
+      },
+      "name": "Unbranded Plastic Hat",
+      "description": "The Apollotech B340 is an affordable wireless mouse with reliable connectivity, 12 months battery life and modern design",
+      "sizeOrAmount": {
+        "type": "QuantitativeValue",
+        "unitCode": "hg/ha",
+        "value": "3306"
+      },
+      "weight": {
+        "type": "QuantitativeValue",
+        "unitCode": "hg/ha",
+        "value": "2452"
+      },
+      "sku": "407472905958"
+    },
+    {
+      "@context": [
+        "https://w3id.org/traceability/v1"
+      ],
+      "type": "Product",
+      "manufacturer": {
+        "type": "Organization",
+        "name": "Sanford - Legros",
+        "description": "Cross-group content-based migration",
+        "address": {
+          "type": "PostalAddress",
+          "streetAddress": "291 Torp Summit",
+          "addressLocality": "Americaport",
+          "addressRegion": "Tennessee",
+          "postalCode": "23280",
+          "addressCountry": "Spain"
+        },
+        "email": "Selmer_Upton43@hotmail.com",
+        "phoneNumber": "(872) 937-5989"
+      },
+      "name": "Sleek Wooden Sausages",
+      "description": "Andy shoes are designed to keeping in mind durability as well as trends, the most stylish range of shoes & sandals",
+      "sizeOrAmount": {
+        "type": "QuantitativeValue",
+        "unitCode": "hg/ha",
+        "value": "8972"
+      },
+      "weight": {
+        "type": "QuantitativeValue",
+        "unitCode": "hg/ha",
+        "value": "3156"
+      },
+      "sku": "475876054302"
+    }
+  ],
+  "bad": [
+    {
+      "weight": {
+        "type": "QuantitativeValue",
+        "unitCode": "hg/ha",
+        "value": "8206"
+      },
+      "sku": "43632142035",
+      "circuit": "copy",
+      "interface": "reboot",
+      "alarm": "quantify"
+    },
+    {
+      "@context": [
+        "https://w3id.org/traceability/v1"
+      ],
+      "manufacturer": {
+        "type": "Person",
+        "firstName": "Yazmin",
+        "lastName": "Abernathy",
+        "email": "Sven.Schmeler@yahoo.com",
+        "phoneNumber": "(488) 716-9876 x18990",
+        "worksFor": {
+          "type": "Organization",
+          "name": "Dietrich - Reichel",
+          "description": "Reduced web-enabled extranet",
+          "address": {
+            "type": "PostalAddress",
+            "streetAddress": "3646 Aurelie Point",
+            "addressLocality": "Tessieberg",
+            "addressRegion": "Oregon",
+            "postalCode": "28003-5169",
+            "addressCountry": "Sao Tome and Principe"
+          },
+          "email": "Gideon4@yahoo.com",
+          "phoneNumber": "870.993.9296"
+        },
+        "jobTitle": "National Brand Director"
+      },
+      "description": "The Apollotech B340 is an affordable wireless mouse with reliable connectivity, 12 months battery life and modern design",
+      "weight": {
+        "type": "QuantitativeValue",
+        "unitCode": "hg/ha",
+        "value": "2452"
+      },
+      "firewall": "hack"
+    },
+    {
+      "@context": [
+        "https://w3id.org/traceability/v1"
+      ],
+      "manufacturer": {
+        "type": "Organization",
+        "name": "Sanford - Legros",
+        "description": "Cross-group content-based migration",
+        "address": {
+          "type": "PostalAddress",
+          "streetAddress": "291 Torp Summit",
+          "addressLocality": "Americaport",
+          "addressRegion": "Tennessee",
+          "postalCode": "23280",
+          "addressCountry": "Spain"
+        },
+        "email": "Selmer_Upton43@hotmail.com",
+        "phoneNumber": "(872) 937-5989"
+      },
+      "name": "Sleek Wooden Sausages",
+      "description": "Andy shoes are designed to keeping in mind durability as well as trends, the most stylish range of shoes & sandals",
+      "sizeOrAmount": {
+        "type": "QuantitativeValue",
+        "unitCode": "hg/ha",
+        "value": "8972"
+      },
+      "weight": {
+        "type": "QuantitativeValue",
+        "unitCode": "hg/ha",
+        "value": "3156"
+      },
+      "sku": "475876054302",
+      "panel": "override",
+      "alarm": "navigate",
+      "sensor": "quantify"
+    }
+  ]
+}

--- a/docs/test-vectors/QuantitativeValue.json
+++ b/docs/test-vectors/QuantitativeValue.json
@@ -1,0 +1,51 @@
+{
+  "good": [
+    {
+      "@context": [
+        "https://w3id.org/traceability/v1"
+      ],
+      "type": "QuantitativeValue",
+      "unitCode": "hg/ha",
+      "value": "7845"
+    },
+    {
+      "@context": [
+        "https://w3id.org/traceability/v1"
+      ],
+      "type": "QuantitativeValue",
+      "unitCode": "hg/ha",
+      "value": "7816"
+    },
+    {
+      "@context": [
+        "https://w3id.org/traceability/v1"
+      ],
+      "type": "QuantitativeValue",
+      "unitCode": "hg/ha",
+      "value": "6399"
+    }
+  ],
+  "bad": [
+    {
+      "type": "QuantitativeValue",
+      "program": "override",
+      "interface": "connect",
+      "sensor": "compress"
+    },
+    {
+      "type": "QuantitativeValue",
+      "monitor": "navigate",
+      "bandwidth": "quantify",
+      "port": "generate"
+    },
+    {
+      "@context": [
+        "https://w3id.org/traceability/v1"
+      ],
+      "type": "QuantitativeValue",
+      "unitCode": "hg/ha",
+      "circuit": "compress",
+      "application": "parse"
+    }
+  ]
+}

--- a/packages/test-vectors/src/__fixtures__/index.js
+++ b/packages/test-vectors/src/__fixtures__/index.js
@@ -1,27 +1,40 @@
 const GeoCoordinates = require('../../../../docs/test-vectors/GeoCoordinates.json');
+const Inspector = require('../../../../docs/test-vectors/Inspector.json');
 const Place = require('../../../../docs/test-vectors/Place.json');
 const PostalAddress = require('../../../../docs/test-vectors/PostalAddress.json');
 const Observation = require('../../../../docs/test-vectors/Observation.json');
 const Credential = require('../../../../docs/test-vectors/Credential.json');
-const Inspector = require('../../../../docs/test-vectors/Inspector.json');
 const InspectionReport = require('../../../../docs/test-vectors/InspectionReport.json');
+const ParcelDelivery = require('../../../../docs/test-vectors/ParcelDelivery.json');
+const QuantitativeValue = require('../../../../docs/test-vectors/QuantitativeValue.json');
+const Organization = require('../../../../docs/test-vectors/Organization.json');
+const Person = require('../../../../docs/test-vectors/Person.json');
+const Entity = require('../../../../docs/test-vectors/Entity.json');
 const AgInspectionReport = require('../../../../docs/test-vectors/AgInspectionReport.json');
 const MeasuredProperty = require('../../../../docs/test-vectors/MeasuredProperty.json');
 const MeasuredValue = require('../../../../docs/test-vectors/MeasuredValue.json');
 const ChemicalProperty = require('../../../../docs/test-vectors/ChemicalProperty.json');
 const MechanicalProperty = require('../../../../docs/test-vectors/MechanicalProperty.json');
+const Product = require('../../../../docs/test-vectors/Product.json');
+
 
 module.exports = {
   GeoCoordinates,
+  Inspector,
   Place,
   PostalAddress,
   Observation,
   Credential,
-  Inspector,
   InspectionReport,
+  ParcelDelivery,
+  QuantitativeValue,
+  Organization,
+  Person,
+  Entity,
   AgInspectionReport,
   MeasuredProperty,
   MeasuredValue,
   ChemicalProperty,
   MechanicalProperty,
+  Product
 };

--- a/packages/test-vectors/src/__tests__/linked-data-conformance.test.js
+++ b/packages/test-vectors/src/__tests__/linked-data-conformance.test.js
@@ -46,9 +46,10 @@ Object.values(intermediateJson).forEach((classDefinition) => {
           resultOk = await jsonldChecker.check(goodExample, customDocumentLoader);
           //Adding some slightly better error handling
           if (resultOk.error.type != '') {
+
             console.log(classDefinition.title);
-            console.log(resultOk.error.type);
-            console.log(resultOk.error.details);
+            console.log(resultOk.error);
+
           }
           return expect(resultOk.ok).toBe(true);
         }));

--- a/packages/test-vectors/src/generators/AgInspectionReport.js
+++ b/packages/test-vectors/src/generators/AgInspectionReport.js
@@ -2,6 +2,8 @@ const faker = require('faker');
 const _ = require('lodash');
 const { getPlace } = require('./Place');
 const { getInspector } = require('./Inspector');
+const { getParcelDelivery } = require('./ParcelDelivery');
+const { getEntity } = require('./Entity');
 const { getObservation } = require('./Observation');
 //Include test data for inspection type.  This data is very rudimentary for now, and it is probably overkill to have a separate file, but it might be useful in the future across multiple Ag schemas.
 const agTypes = require('../../data/generated/AgInspection-types.json');
@@ -60,18 +62,18 @@ const getAgInspectionReport = () => {
     const inspector = getInspector();
     delete inspector['@context'];
     const inspectDate = new Date(faker.date.recent());
+    const shipment = getParcelDelivery();
+    delete shipment['@context'];
+    const applicant = getEntity();
+    delete applicant['@context'];
 
     const example = {
         '@context': ['https://w3id.org/traceability/v1'],
         type: 'AgInspectionReport',
         facility,
         inspector,
-        shipment: {
-            sku: faker.random.number({ min: 10000000, max: 999999999999 }),
-            itemShipped,
-            provider: faker.company.companyName()
-        },
-        applicantId: faker.random.number({ min: 100000, max: 9999999 }),
+        shipment,
+        applicant,
         inspectionDate: inspectDate.getMonth() + "-" + inspectDate.getDay() + "-" + inspectDate.getFullYear(),
         inspectionType,
         observation,

--- a/packages/test-vectors/src/generators/Entity.js
+++ b/packages/test-vectors/src/generators/Entity.js
@@ -1,0 +1,18 @@
+const faker = require('faker');
+
+const { getPerson } = require('./Person');
+const { getOrganization } = require('./Organization');
+
+const getEntity = () => {
+    const randomType = faker.random.arrayElement(['person', 'organization']);
+
+    if (randomType === 'person') {
+        const prop = getPerson();
+        return prop;
+    }
+
+    const prop = getOrganization();
+    return prop;
+};
+
+module.exports = { getEntity };

--- a/packages/test-vectors/src/generators/Inspector.js
+++ b/packages/test-vectors/src/generators/Inspector.js
@@ -1,7 +1,9 @@
 const faker = require('faker');
 const { getCredential } = require('./Credential');
+const { getPerson } = require('./Person');
 
 const getInspector = () => {
+  //get credentials
   let credential = [];
   let numCreds = faker.random.number({ min: 1, max: 3 });
   while (numCreds > 0) {
@@ -10,10 +12,15 @@ const getInspector = () => {
     credential.push(cred);
     numCreds -= 1;
   }
+
+  //Get Person 
+  const person = getPerson();
+  delete person['@context'];
+
   const example = {
     '@context': ['https://w3id.org/traceability/v1'],
     type: 'Inspector',
-    person: faker.name.findName(),
+    person,
     credential
   };
   return example;

--- a/packages/test-vectors/src/generators/Organization.js
+++ b/packages/test-vectors/src/generators/Organization.js
@@ -1,0 +1,24 @@
+const faker = require('faker');
+const { getPostalAddress } = require('./PostalAddress');
+
+const getOrganization = () => {
+
+    //Get address 
+    const address = getPostalAddress();
+    delete address['@context'];
+    //remove Organization name from the PostalAddress schema we're pulling in
+    delete address['organizationName'];
+
+    const example = {
+        '@context': ['https://w3id.org/traceability/v1'],
+        type: 'Organization',
+        name: faker.company.companyName(),
+        description: faker.company.catchPhrase(),
+        address,
+        email: faker.internet.email(),
+        phoneNumber: faker.phone.phoneNumber()
+    };
+    return example;
+};
+
+module.exports = { getOrganization };

--- a/packages/test-vectors/src/generators/ParcelDelivery.js
+++ b/packages/test-vectors/src/generators/ParcelDelivery.js
@@ -1,0 +1,34 @@
+const faker = require('faker');
+const { getPostalAddress } = require('./PostalAddress');
+const { getProduct } = require('./Product');
+
+const getParcelDelivery = () => {
+
+    //Get address 
+    const deliveryAddress = getPostalAddress();
+    delete deliveryAddress['@context'];
+
+    const originAddress = getPostalAddress();
+    delete originAddress['@context'];
+
+    let products = [];
+    let numProds = faker.random.number({ min: 1, max: 3 });
+    while (numProds > 0) {
+        const prod = getProduct();
+        delete prod['@context'];
+        products.push(prod);
+        numProds -= 1;
+    }
+
+    const example = {
+        '@context': ['https://w3id.org/traceability/v1'],
+        type: 'ParcelDelivery',
+        deliveryAddress,
+        originAddress,
+        trackingNumber: faker.random.number({ min: 10000000, max: 999999999999 }).toString(),
+        products
+    };
+    return example;
+};
+
+module.exports = { getParcelDelivery };

--- a/packages/test-vectors/src/generators/Person.js
+++ b/packages/test-vectors/src/generators/Person.js
@@ -1,0 +1,23 @@
+const faker = require('faker');
+const { getOrganization } = require('./Organization');
+
+const getPerson = () => {
+
+    //Get organization
+    const worksFor = getOrganization();
+    delete worksFor['@context'];
+
+    const example = {
+        '@context': ['https://w3id.org/traceability/v1'],
+        type: 'Person',
+        firstName: faker.name.firstName(),
+        lastName: faker.name.lastName(),
+        email: faker.internet.email(),
+        phoneNumber: faker.phone.phoneNumber(),
+        worksFor,
+        jobTitle: faker.name.jobTitle()
+    };
+    return example;
+};
+
+module.exports = { getPerson };

--- a/packages/test-vectors/src/generators/Product.js
+++ b/packages/test-vectors/src/generators/Product.js
@@ -1,0 +1,33 @@
+const faker = require('faker');
+const { getEntity } = require('./Entity');
+const { getQuantitativeValue } = require('./QuantitativeValue');
+
+const getProduct = () => {
+
+    //Get Entity
+    const manufacturer = getEntity();
+    delete manufacturer['@context'];
+
+    //Get Quantitative Value for Size
+    const sizeOrAmount = getQuantitativeValue();
+    delete sizeOrAmount['@context'];
+
+    //Get Quantitative Value for Weight
+    const weight = getQuantitativeValue();
+    delete weight['@context'];
+
+    const example = {
+        '@context': ['https://w3id.org/traceability/v1'],
+        type: 'Product',
+        manufacturer,
+        name: faker.commerce.productName(),
+        description: faker.commerce.productDescription(),
+        sizeOrAmount,
+        weight,
+        sku: faker.random.number({ min: 10000000, max: 999999999999 }).toString()
+
+    };
+    return example;
+};
+
+module.exports = { getProduct };

--- a/packages/test-vectors/src/generators/QuantitativeValue.js
+++ b/packages/test-vectors/src/generators/QuantitativeValue.js
@@ -1,0 +1,21 @@
+const faker = require('faker');
+//Include test data for Ag product units.
+const prods = require('../../data/generated/AgProducts.json');
+
+const getQuantitativeValue = () => {
+    //get a product
+    const randomProd = Object.keys(prods)[
+        faker.random.number(Object.keys(prods).length - 1)
+    ];
+    const unitCode = prods[randomProd].Unit;
+
+    const example = {
+        '@context': ['https://w3id.org/traceability/v1'],
+        type: 'QuantitativeValue',
+        unitCode,
+        value: faker.random.number({ min: 10, max: 10000 }).toString()
+    };
+    return example;
+};
+
+module.exports = { getQuantitativeValue };

--- a/packages/test-vectors/src/generators/config.js
+++ b/packages/test-vectors/src/generators/config.js
@@ -5,10 +5,16 @@ const { getChemicalProperty } = require('./ChemicalProperty');
 const { getMechanicalProperty } = require('./MechanicalProperty');
 const { getMeasuredProperty } = require('./MeasuredProperty');
 const { getMeasuredValue } = require('./MeasuredValue');
+const { getInspector } = require('./Inspector');
 const { getObservation } = require('./Observation');
 const { getCredential } = require('./Credential');
-const { getInspector } = require('./Inspector');
 const { getInspectionReport } = require('./InspectionReport');
+const { getQuantitativeValue } = require('./QuantitativeValue');
+const { getOrganization } = require('./Organization');
+const { getParcelDelivery } = require('./ParcelDelivery');
+const { getPerson } = require('./Person');
+const { getEntity } = require('./Entity');
+const { getProduct } = require('./Product');
 const { getAgInspectionReport } = require('./AgInspectionReport');
 
 const generatorConfig = {
@@ -19,10 +25,16 @@ const generatorConfig = {
   MechanicalProperty: getMechanicalProperty,
   MeasuredProperty: getMeasuredProperty,
   MeasuredValue: getMeasuredValue,
-  Observation: getObservation,
-  Credential: getCredential,
   Inspector: getInspector,
+  Observation: getObservation,
+  ParcelDelivery: getParcelDelivery,
+  Credential: getCredential,
   InspectionReport: getInspectionReport,
+  QuantitativeValue: getQuantitativeValue,
+  Organization: getOrganization,
+  Person: getPerson,
+  Entity: getEntity,
+  Product: getProduct,
   AgInspectionReport: getAgInspectionReport
 };
 


### PR DESCRIPTION
After discussion in issue #32 I've taken all $ref referenced to external schemas on schema.org and brought those schemas locally, including only the properties needed for the schemas in the traceability repo.  Also, this has required some general restructuring for existing schemas related to AgInspectionReport.json.
The new added schemas coming from schema.org are:
- Organization.json
- Person.json
- Product.json
- QuantitativeValue.json (for weight and/or size of Products)
- ParcelDelivery.json (for shipments of Products)

Also the Entity.json schema was created to describe an entity that could either be a Person or an Organization.

All testing was run and passed.